### PR TITLE
chore: add logo to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-# BookHub
+<p align="center">
+  <img src="icons/icon128.png" alt="BookHub Logo" width="128" height="128">
+</p>
 
-A browser extension that bidirectionally syncs your bookmarks with a GitHub repository. Supports Chrome and Firefox.
+<h1 align="center">BookHub</h1>
+
+<p align="center">
+  A browser extension that bidirectionally syncs your bookmarks with a GitHub repository.<br>
+  Supports Chrome and Firefox.
+</p>
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Adds the BookHub icon (128x128) centered at the top of the README
- Title and description are centered below the logo

## Test plan

- [ ] Verify logo renders correctly on GitHub README page

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only formatting change; no runtime code or behavior is affected.
> 
> **Overview**
> Refreshes `README.md` presentation by adding a centered logo image (`icons/icon128.png`) at the top and converting the title/intro text to centered HTML formatting (including a line break between description lines).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e22cde0e1a9bfadfebfeecd700cea75795db0e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->