### PR TITLE
chore: release v2.1.1 with new icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - TBD
+
+### Changed
+
+- **New icon**: Updated logo (blue bookmark + green sync arrow on black background) across extension, store assets, and favicons
+
 ## [2.1.0] - 2025-02-10
 
 ### Added
@@ -93,7 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release: bookmark sync with GitHub
 
-[Unreleased]: https://github.com/d0dg3r/GitSyncMarks/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/d0dg3r/GitSyncMarks/compare/v2.1.1...HEAD
+[2.1.1]: https://github.com/d0dg3r/GitSyncMarks/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/d0dg3r/GitSyncMarks/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/d0dg3r/GitSyncMarks/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/d0dg3r/GitSyncMarks/compare/v1.5.0...v2.0.0

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 <h1 align="center">GitSyncMarks</h1>
 
 <p align="center">
+  <a href="https://github.com/d0dg3r/GitSyncMarks/releases"><img src="https://img.shields.io/github/v/release/d0dg3r/GitSyncMarks" alt="Release"></a>
+</p>
+
+<p align="center">
   A browser extension that bidirectionally syncs your bookmarks with a GitHub repository.<br>
   Supports Chrome and Firefox.
 </p>

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -30,6 +30,7 @@ The version is declared in `manifest.json` → `"version"`. It must match `manif
 | `1.5.0` | Token encryption at rest (AES-256-GCM), token moved to local storage |
 | `2.0.0` | Per-file bookmark storage, three-way merge sync, Firefox support, automation (GitHub Actions), cross-browser build system |
 | `2.0.1` | Fix: false merge conflicts when two devices edit the same folder concurrently (`_order.json` content-level merge); harden GitHub Action inputs; update Firefox manifest and i18n; update store screenshots |
+| `2.1.1` | New icon (blue bookmark + green sync arrow) for extension, store assets, and favicons |
 | `2.1.0` | Sync profiles, sync on startup/focus, theme (light/dark/auto), redesigned Backup tab, tabbed options (GitHub/Sync/Backup), commit link in popup, pre-release workflow — see [CHANGELOG.md](../CHANGELOG.md) |
 
 ## How to Create a New Release

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "GitSyncMarks",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "homepage_url": "https://github.com/d0dg3r/GitSyncMarks",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "GitSyncMarks",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "homepage_url": "https://github.com/d0dg3r/GitSyncMarks",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitsyncmarks",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitsyncmarks",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "devDependencies": {
         "png-to-ico": "^2.1.0",
         "sharp": "^0.33.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitsyncmarks",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "description": "Your bookmarks, safe on GitHub — per-file storage, three-way merge sync, works on Chrome & Firefox. No server needed.",
   "scripts": {


### PR DESCRIPTION
This pull request prepares for version 2.1.1 of the GitSyncMarks extension, focusing primarily on updating the extension's icon and associated assets. It also includes version bumps and documentation updates to reflect the new release.

Branding and assets:

* Updated the extension logo to a new design (blue bookmark + green sync arrow on black background) across the extension, store assets, and favicons. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R15) [[2]](diffhunk://#diff-9c4ae3b5f6675180493e9a1a817baabf4c5314870a3fa67c9c6ab89186046a91R33)

Versioning and documentation:

* Bumped the version to `2.1.1` in `manifest.json`, `manifest.firefox.json`, and `package.json`. [[1]](diffhunk://#diff-2376336c746fc275f91fcfa11a372f1e03d2d62f7cb1f2bf8854aa752c13dcddL5-R5) [[2]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L5-R5) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)
* Updated release links and changelog to reference version 2.1.1.
* Added a release badge to the top of the `README.md` for improved visibility of the current version.