### PR TITLE
chore: bump version to v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.2] - 2025-02-13
+
+### Added
+
+- **Store buttons in README**: Chrome Web Store and Firefox Add-on badges with direct links
+- **Testing guide** ([docs/TESTING.md](docs/TESTING.md)): Instructions for Chrome, Firefox desktop, and Firefox Android
+
+### Changed
+
+- **Responsive mobile layout** for Firefox Android: Popup and options page adapt to narrow viewports; tab bar scrolls horizontally; header stacks on small screens
+
 ## [2.1.1] - TBD
 
 ### Changed

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -30,6 +30,7 @@ The version is declared in `manifest.json` → `"version"`. It must match `manif
 | `1.5.0` | Token encryption at rest (AES-256-GCM), token moved to local storage |
 | `2.0.0` | Per-file bookmark storage, three-way merge sync, Firefox support, automation (GitHub Actions), cross-browser build system |
 | `2.0.1` | Fix: false merge conflicts when two devices edit the same folder concurrently (`_order.json` content-level merge); harden GitHub Action inputs; update Firefox manifest and i18n; update store screenshots |
+| `2.1.2` | Store buttons in README, responsive mobile layout for Firefox Android, testing guide (docs/TESTING.md) |
 | `2.1.1` | New icon (blue bookmark + green sync arrow) for extension, store assets, and favicons |
 | `2.1.0` | Sync profiles, sync on startup/focus, theme (light/dark/auto), redesigned Backup tab, tabbed options (GitHub/Sync/Backup), commit link in popup, pre-release workflow — see [CHANGELOG.md](../CHANGELOG.md) |
 

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "GitSyncMarks",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "homepage_url": "https://github.com/d0dg3r/GitSyncMarks",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "GitSyncMarks",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "homepage_url": "https://github.com/d0dg3r/GitSyncMarks",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitsyncmarks",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "Your bookmarks, safe on GitHub — per-file storage, three-way merge sync, works on Chrome & Firefox. No server needed.",
   "scripts": {


### PR DESCRIPTION
This pull request prepares the project for the `2.1.2` release with updates to version numbers, documentation, and changelogs. The main highlights are the addition of store badges and a new testing guide, as well as improvements for mobile responsiveness on Firefox Android.

Release and documentation updates:

* Bump version to `2.1.2` in `manifest.json`, `manifest.firefox.json`, and `package.json` to reflect the new release. [[1]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L5-R5) [[2]](diffhunk://#diff-2376336c746fc275f91fcfa11a372f1e03d2d62f7cb1f2bf8854aa752c13dcddL5-R5) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)
* Add a new entry for `2.1.2` in `CHANGELOG.md` describing the addition of Chrome Web Store and Firefox Add-on badges in the README, a new testing guide (`docs/TESTING.md`), and improved responsive mobile layout for Firefox Android.
* Update the release history table in `docs/RELEASE.md` to include the `2.1.2` release and its key features.