### PR TITLE
Release v2.5.1: fix password dialog placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to GitSyncMarks are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1] - 2026-02-25 (*Cortana*)
+
+### Fixed
+
+- **Password dialog placement**: Password prompt for Settings sync actions (Import & Apply, Sync current to selected, Create my client setting) now appears in the Settings sub-tab instead of the Export/Import sub-tab
+
 ## [2.5.0] - 2026-02-23 (*Cortana*)
 
 ### Added
@@ -212,7 +218,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release: bookmark sync with GitHub
 
-[Unreleased]: https://github.com/d0dg3r/GitSyncMarks/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/d0dg3r/GitSyncMarks/compare/v2.5.1...HEAD
+[2.5.1]: https://github.com/d0dg3r/GitSyncMarks/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/d0dg3r/GitSyncMarks/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/d0dg3r/GitSyncMarks/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/d0dg3r/GitSyncMarks/compare/v2.2.1...v2.3.0

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -38,6 +38,7 @@ The version is declared in `manifest.json` → `"version"`. It must match `manif
 
 | Version | Codename | Description |
 |---|---|---|
+| `2.5.1` | *Cortana* | Fix: password dialog for Settings sync actions (Import & Apply, etc.) now appears in Settings sub-tab instead of Export/Import |
 | `2.5.0` | *Cortana* | Context menu (Add to Toolbar/Other, Sync Now, Switch Profile, Copy Favicon URL, Download Favicon); profile switching via context menu; favicon tools; 8 new languages (PT-BR, IT, JA, ZH-CN, KO, RU, TR, PL — 12 total); dynamic keyboard shortcuts; factory reset; folder browser; CI screenshot workflow; feature lists reordered; "No middleman" replaces "No server needed"; 9 store screenshots per language |
 | `2.4.0` | *R2-D2* | Settings sync to Git (encrypted `settings.enc` in repo); RSS feed export (`feed.xml`); dashy-conf.yml; generated files mode selector (Off/Manual/Auto per file with "Generate now" button); backlog voting awareness; Debug Log moved to Sync tab; options reorganized to 5 tabs with sub-tabs (GitHub/Sync/Files/Help/About); 6 store screenshots per language |
 | `2.3.0` | *Data* | Encrypted settings export (password-protected .enc); plain JSON and encrypted formats supported; import with password prompt for .enc files; Sync tab shortened to "Sync"; store screenshots (popup crop, options resize); import hints (active profile / all profiles); theme cycle button; full auto-save (no Save buttons); save feedback in cards |

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "GitSyncMarks",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "homepage_url": "https://github.com/d0dg3r/GitSyncMarks",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "GitSyncMarks",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "homepage_url": "https://github.com/d0dg3r/GitSyncMarks",

--- a/options.html
+++ b/options.html
@@ -535,18 +535,6 @@
               <span id="import-result" class="ie-result"></span>
             </div>
           </div>
-
-          <div id="password-dialog" class="profile-inline-dialog" style="display: none;">
-            <div class="profile-inline-dialog-body">
-              <p id="password-dialog-prompt" class="profile-inline-dialog-text"></p>
-              <label for="password-dialog-input" class="profile-inline-dialog-label" data-i18n="options_passwordPlaceholder">Password</label>
-              <input type="password" id="password-dialog-input" class="profile-inline-dialog-input" autocomplete="off">
-            </div>
-            <div class="profile-inline-dialog-actions">
-              <button type="button" id="password-dialog-confirm-btn" class="btn btn-primary btn-sm" data-i18n="options_exportBtn">Export</button>
-              <button type="button" id="password-dialog-cancel-btn" class="btn btn-secondary btn-sm" data-i18n="options_profileSwitchCancelBtn">Cancel</button>
-            </div>
-          </div>
         </section>
       </div>
 
@@ -598,6 +586,18 @@
             </table>
           </div>
         </section>
+      </div>
+
+      <div id="password-dialog" class="profile-inline-dialog" style="display: none;">
+        <div class="profile-inline-dialog-body">
+          <p id="password-dialog-prompt" class="profile-inline-dialog-text"></p>
+          <label for="password-dialog-input" class="profile-inline-dialog-label" data-i18n="options_passwordPlaceholder">Password</label>
+          <input type="password" id="password-dialog-input" class="profile-inline-dialog-input" autocomplete="off">
+        </div>
+        <div class="profile-inline-dialog-actions">
+          <button type="button" id="password-dialog-confirm-btn" class="btn btn-primary btn-sm" data-i18n="options_exportBtn">Export</button>
+          <button type="button" id="password-dialog-cancel-btn" class="btn btn-secondary btn-sm" data-i18n="options_profileSwitchCancelBtn">Cancel</button>
+        </div>
       </div>
 
     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitsyncmarks",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "description": "Your bookmarks, safe on GitHub — per-file storage, three-way merge sync, works on Chrome & Firefox. No middleman.",
   "scripts": {


### PR DESCRIPTION
- Password prompt for Settings sync actions (Import & Apply, etc.) now appears in the Settings sub-tab instead of Export/Import
- Move password-dialog to shared location under Files tab
