### PR TITLE
Update .gitignore to include _site directory, add website preview scr…

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,57 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - 'store-assets/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare site
+        run: |
+          mkdir -p _site/assets/screenshots
+          touch _site/.nojekyll
+          cp website/index.html website/styles.css _site/
+          cp store-assets/marquee_promo_tile.jpg _site/assets/
+          cp store-assets/en/chrome-1-github.png \
+             store-assets/en/chrome-2-connection.png \
+             store-assets/en/chrome-3-sync.png \
+             store-assets/en/chrome-4-files.png \
+             store-assets/en/chrome-5-export-import.png \
+             store-assets/en/chrome-6-popup.png \
+             store-assets/en/chrome-7-wizard-welcome.png \
+             store-assets/en/chrome-8-wizard-token.png \
+             store-assets/en/chrome-9-wizard-repo.png _site/assets/screenshots/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 build/
+_site/
 *.zip
 .favicon-48-tmp.png
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ In the **Help** tab of the options page:
 
 ## Documentation & Links
 
+- **[Website](https://d0dg3r.github.io/GitSyncMarks/)** — Project landing page
 - **[Backlog Poll](https://github.com/d0dg3r/GitSyncMarks/discussions/37)** — Vote on which features to prioritize next
 - **[Discussions](https://github.com/d0dg3r/GitSyncMarks/discussions)** — Q&A, ideas, show and tell; see [docs/GITHUB-DISCUSSIONS.md](docs/GITHUB-DISCUSSIONS.md) for category overview
 - **[GitSyncMarks-App](https://github.com/d0dg3r/GitSyncMarks-App)** — Cross-platform companion (Android, iOS, Windows, macOS, Linux); move/reorder/add bookmarks; encrypted settings sync

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:e2e:smoke": "npm run build:chrome && npx playwright test e2e/smoke.spec.js",
     "test:e2e:sync": "npm run build:chrome && npx playwright test e2e/connection.spec.js e2e/sync.spec.js",
     "test:e2e:report": "npx playwright show-report",
-    "cleanup:e2e-repos": "node scripts/cleanup-e2e-repos.js"
+    "cleanup:e2e-repos": "node scripts/cleanup-e2e-repos.js",
+    "website:preview": "bash scripts/prepare-website.sh && npx --yes serve _site -p 3000"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/scripts/prepare-website.sh
+++ b/scripts/prepare-website.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Prepare website for deployment or local preview.
+# Copies website files and store assets into _site/.
+
+set -e
+cd "$(dirname "$0")/.."
+
+mkdir -p _site/assets/screenshots
+touch _site/.nojekyll
+cp website/index.html website/styles.css _site/
+cp store-assets/marquee_promo_tile.jpg _site/assets/
+cp store-assets/en/chrome-1-github.png \
+   store-assets/en/chrome-2-connection.png \
+   store-assets/en/chrome-3-sync.png \
+   store-assets/en/chrome-4-files.png \
+   store-assets/en/chrome-5-export-import.png \
+   store-assets/en/chrome-6-popup.png \
+   store-assets/en/chrome-7-wizard-welcome.png \
+   store-assets/en/chrome-8-wizard-token.png \
+   store-assets/en/chrome-9-wizard-repo.png _site/assets/screenshots/
+
+echo "Website prepared in _site/"

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="GitSyncMarks — Your bookmarks, safe on GitHub. Per-file storage, three-way merge sync, works on Chrome & Firefox. No middleman.">
+  <title>GitSyncMarks — Effortless Bookmark Sync via GitHub</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="hero">
+    <img src="assets/marquee_promo_tile.jpg" alt="GitSyncMarks — Effortless Bookmark Sync via GitHub" class="hero-image" width="960">
+    <div class="hero-content">
+      <h1>GitSyncMarks</h1>
+      <p class="tagline">Effortless Bookmark Sync via GitHub</p>
+      <p class="subtitle">Your bookmarks live in <em>your</em> Git repo. Per-file storage, three-way merge, no middleman — syncs directly via the GitHub API.</p>
+      <nav class="quick-nav">
+        <a href="#features">Features</a>
+        <a href="#how-it-works">How it works</a>
+        <a href="#installation">Installation</a>
+        <a href="#screenshots">Screenshots</a>
+      </nav>
+      <div class="badges">
+        <a href="https://chromewebstore.google.com/detail/kogijidhfkoibgihpiaiippajhgdgmif" class="badge badge-chrome">Chrome Web Store</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/gitsyncmarks/" class="badge badge-firefox">Firefox Add-on</a>
+        <a href="https://github.com/d0dg3r/GitSyncMarks/releases" class="badge">Releases</a>
+        <a href="https://github.com/d0dg3r/GitSyncMarks-App" class="badge badge-app">Companion App</a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="intro">
+      <p class="lead">A browser extension that bidirectionally syncs your bookmarks with a GitHub repository. Works with Chrome, Chromium, Brave, Edge, and Firefox. No third-party server — your data stays between your browser and your repo.</p>
+    </section>
+
+    <section class="features" id="features">
+      <h2>Core Features</h2>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <h3>No middleman</h3>
+          <p>Communicates directly with the GitHub API. No third-party server, no backend. Your data stays between your browser and your GitHub repo.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Per-file storage</h3>
+          <p>Each bookmark is stored as an individual JSON file in your Git repo — human-readable, diff-friendly, and easy to edit or version on GitHub.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Three-way merge</h3>
+          <p>Automatic conflict-free sync when changes happen on both sides simultaneously. No manual merge needed in most cases.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Cross-browser</h3>
+          <p>Works with Chrome, Chromium, Brave, Edge, and Firefox. Same extension logic, same bookmark format across all.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Auto-sync</h3>
+          <p>Syncs automatically on every bookmark change. Configurable debounce so rapid edits are bundled into one sync.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="power-features">
+      <h2>Power Features</h2>
+      <ul class="power-list">
+        <li><strong>Multiple profiles</strong> — Up to 10 profiles (work, personal, projects). Each has its own GitHub repo config and bookmark set. Switch replaces local bookmarks with the target profile.</li>
+        <li><strong>Context menu</strong> — Right-click on any page or link: Add to Toolbar, Add to Other Bookmarks, Sync Now, Switch Profile, Copy Favicon URL, Download Favicon. Bookmark auto-syncs after adding.</li>
+        <li><strong>Automation</strong> — Add bookmarks via Git, CLI, or GitHub Actions. The extension picks them up automatically on the next sync.</li>
+        <li><strong>GitHub Repos folder</strong> — Optional folder with bookmarks to all your GitHub repositories (public and private). Configurable position (toolbar/other).</li>
+      </ul>
+    </section>
+
+    <section class="generated-files">
+      <h2>Generated Files</h2>
+      <p>GitSyncMarks can generate these files in your repo on each sync (each configurable as Off, Manual, or Auto):</p>
+      <ul>
+        <li><strong>README.md</strong> — Markdown overview of all bookmarks; browse directly on GitHub</li>
+        <li><strong>bookmarks.html</strong> — Netscape format; import into Chrome, Firefox, or Edge</li>
+        <li><strong>feed.xml</strong> — RSS 2.0 feed; subscribe in any reader or use for automations</li>
+        <li><strong>dashy-conf.yml</strong> — Config for the <a href="https://github.com/Lissy93/dashy">Dashy</a> dashboard</li>
+      </ul>
+    </section>
+
+    <section class="sync-config">
+      <h2>Sync Configuration</h2>
+      <p>Flexible sync behavior to match your workflow:</p>
+      <ul>
+        <li><strong>Sync profiles</strong> — Real-time (1 min), Frequent (5 min), Normal (15 min), Power save (60 min), or Custom</li>
+        <li><strong>Sync on startup / focus</strong> — Optional sync when the browser starts or gains focus (with cooldown)</li>
+        <li><strong>Manual sync</strong> — Push, Pull, or full Sync via popup buttons</li>
+        <li><strong>Conflict detection</strong> — Notifies when automatic merge is not possible; choose Push or Pull</li>
+      </ul>
+    </section>
+
+    <section class="how-it-works" id="how-it-works">
+      <h2>How It Works</h2>
+      <ol class="steps">
+        <li>Create a GitHub repository for your bookmarks</li>
+        <li>Generate a <a href="https://github.com/settings/tokens/new?scopes=repo&description=GitSyncMarks+Sync">Personal Access Token</a> with the <code>repo</code> scope</li>
+        <li>Install the extension and configure token, repo owner, repo name, branch, and file path</li>
+        <li>Click <strong>Sync Now</strong> — your bookmarks are pushed as individual JSON files</li>
+      </ol>
+    </section>
+
+    <section class="installation" id="installation">
+      <h2>Installation</h2>
+      <div class="install-tabs">
+        <div class="install-block">
+          <h3>Chrome / Chromium / Edge / Brave</h3>
+          <ol>
+            <li>Go to the <a href="https://github.com/d0dg3r/GitSyncMarks/releases">Releases page</a></li>
+            <li>Download <code>GitSyncMarks-vX.X.X-chrome.zip</code></li>
+            <li>Extract the ZIP to a folder</li>
+            <li>Open <code>chrome://extensions/</code>, enable <strong>Developer mode</strong></li>
+            <li>Click <strong>Load unpacked</strong> and select the extracted folder</li>
+          </ol>
+          <p>Or install from the <a href="https://chromewebstore.google.com/detail/kogijidhfkoibgihpiaiippajhgdgmif">Chrome Web Store</a>.</p>
+        </div>
+        <div class="install-block">
+          <h3>Firefox</h3>
+          <ol>
+            <li>Go to the <a href="https://github.com/d0dg3r/GitSyncMarks/releases">Releases page</a></li>
+            <li>Download <code>GitSyncMarks-vX.X.X-firefox.zip</code></li>
+            <li>Open <code>about:debugging#/runtime/this-firefox</code></li>
+            <li>Click <strong>Load Temporary Add-on</strong> and select the ZIP</li>
+          </ol>
+          <p>For a permanent install, use the <a href="https://addons.mozilla.org/en-US/firefox/addon/gitsyncmarks/">Firefox Add-on</a> store.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="repo-structure">
+      <h2>Repository Structure</h2>
+      <p>After the first sync, your repo contains:</p>
+      <pre><code>bookmarks/
+  _index.json           # Metadata
+  README.md             # Auto-generated overview
+  bookmarks.html        # Netscape import
+  feed.xml              # RSS 2.0 feed
+  toolbar/              # Bookmarks Bar
+    _order.json
+    github_a1b2.json    # One file per bookmark
+  other/                # Other Bookmarks
+    _order.json
+    ...</code></pre>
+      <p>Each bookmark is a simple JSON file: <code>{"title": "GitHub", "url": "https://github.com"}</code></p>
+    </section>
+
+    <section class="automation">
+      <h2>Automation</h2>
+      <p>Add bookmarks without opening the browser:</p>
+      <h3>1. Create a file in the repo</h3>
+      <p>Add a JSON file to <code>bookmarks/toolbar/</code> or <code>bookmarks/other/</code>:</p>
+      <pre><code>{"title": "Example", "url": "https://example.com"}</code></pre>
+      <h3>2. GitHub Action</h3>
+      <p>Copy <a href="https://github.com/d0dg3r/GitSyncMarks/blob/main/.github/workflows/add-bookmark.yml">add-bookmark.yml</a> to your repo and run:</p>
+      <pre><code>gh workflow run add-bookmark.yml -f url="https://example.com" -f title="Example" -f folder="toolbar"</code></pre>
+    </section>
+
+    <section class="screenshots" id="screenshots">
+      <h2>Screenshots</h2>
+      <div class="screenshot-grid">
+        <figure>
+          <img src="assets/screenshots/chrome-1-github.png" alt="GitHub profile settings" width="220">
+          <figcaption>1. GitHub</figcaption>
+        </figure>
+        <figure>
+          <img src="assets/screenshots/chrome-2-connection.png" alt="Connection setup" width="220">
+          <figcaption>2. Connection</figcaption>
+        </figure>
+        <figure>
+          <img src="assets/screenshots/chrome-3-sync.png" alt="Sync status" width="220">
+          <figcaption>3. Sync</figcaption>
+        </figure>
+        <figure>
+          <img src="assets/screenshots/chrome-4-files.png" alt="Generated files" width="220">
+          <figcaption>4. Files</figcaption>
+        </figure>
+        <figure>
+          <img src="assets/screenshots/chrome-5-export-import.png" alt="Export / Import" width="220">
+          <figcaption>5. Export / Import</figcaption>
+        </figure>
+        <figure>
+          <img src="assets/screenshots/chrome-6-popup.png" alt="Extension popup" width="220">
+          <figcaption>6. Popup</figcaption>
+        </figure>
+        <figure>
+          <img src="assets/screenshots/chrome-7-wizard-welcome.png" alt="Setup wizard welcome" width="220">
+          <figcaption>7. Wizard (Welcome)</figcaption>
+        </figure>
+        <figure>
+          <img src="assets/screenshots/chrome-8-wizard-token.png" alt="Setup wizard token" width="220">
+          <figcaption>8. Wizard (Token)</figcaption>
+        </figure>
+        <figure>
+          <img src="assets/screenshots/chrome-9-wizard-repo.png" alt="Setup wizard repository" width="220">
+          <figcaption>9. Wizard (Repository)</figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section class="companion">
+      <h2>Companion App</h2>
+      <p><a href="https://github.com/d0dg3r/GitSyncMarks-App">GitSyncMarks-App</a> — Cross-platform (Android, iOS, Windows, macOS, Linux) that syncs bookmarks from your GitHub repo. View bookmarks on the go, move, reorder, add via share (mobile). Encrypted settings sync. Android stable; F-Droid and Google Play coming soon.</p>
+    </section>
+
+    <section class="troubleshooting">
+      <h2>Troubleshooting</h2>
+      <dl>
+        <dt>Token invalid</dt>
+        <dd>Ensure the PAT has the <code>repo</code> scope; token may have been revoked.</dd>
+        <dt>Repo not found</dt>
+        <dd>Verify Repository Owner and Name; check repo exists and you have access.</dd>
+        <dt>Sync takes long</dt>
+        <dd>Many changed bookmarks = many API calls. Enable Debug Log in Options → Sync for diagnostics.</dd>
+        <dt>Conflict</dt>
+        <dd>Choose Push or Pull in the popup when automatic merge is not possible.</dd>
+      </dl>
+    </section>
+  </main>
+
+  <footer>
+    <nav>
+      <a href="https://github.com/d0dg3r/GitSyncMarks">GitHub</a>
+      <a href="https://github.com/d0dg3r/GitSyncMarks/releases">Releases</a>
+      <a href="https://github.com/d0dg3r/GitSyncMarks/discussions">Discussions</a>
+      <a href="https://github.com/d0dg3r/GitSyncMarks/discussions/37">Backlog Poll</a>
+      <a href="https://github.com/d0dg3r/GitSyncMarks/blob/main/README.md">README</a>
+      <a href="https://github.com/d0dg3r/GitSyncMarks/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/d0dg3r/GitSyncMarks/blob/main/ROADMAP.md">Roadmap</a>
+      <a href="https://github.com/d0dg3r/GitSyncMarks/blob/main/LICENSE">License</a>
+    </nav>
+    <p class="copyright">GitSyncMarks — MIT License · 12 languages · Manifest V3</p>
+  </footer>
+</body>
+</html>

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,377 @@
+/* GitSyncMarks website — comprehensive, readable, responsive */
+
+:root {
+  --bg: #0d1117;
+  --bg-card: #161b22;
+  --bg-elevated: #21262d;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --accent: #58a6ff;
+  --accent-hover: #79b8ff;
+  --border: #30363d;
+  --chrome: #4285f4;
+  --firefox: #ff7139;
+  --app: #6c5ce7;
+  --success: #3fb950;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.hero {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+}
+
+.hero-image {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+}
+
+.hero-content h1 {
+  margin: 0 0 0.25rem;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.tagline {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  color: var(--text-muted);
+}
+
+.subtitle {
+  margin: 0 0 1rem;
+  max-width: 40rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.quick-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+}
+
+.quick-nav a {
+  color: var(--text-muted);
+}
+
+.quick-nav a:hover {
+  color: var(--accent);
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.6rem 1.2rem;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+  background: var(--bg-card);
+  color: var(--text);
+  border: 1px solid var(--border);
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.badge:hover {
+  border-color: var(--accent);
+  background: rgba(88, 166, 255, 0.1);
+}
+
+.badge-chrome:hover {
+  border-color: var(--chrome);
+  background: rgba(66, 133, 244, 0.1);
+}
+
+.badge-firefox:hover {
+  border-color: var(--firefox);
+  background: rgba(255, 113, 57, 0.1);
+}
+
+.badge-app:hover {
+  border-color: var(--app);
+  background: rgba(108, 92, 231, 0.1);
+}
+
+main {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: 0 1rem 3rem;
+}
+
+section {
+  margin-bottom: 3rem;
+}
+
+h2 {
+  font-size: 1.5rem;
+  color: var(--text);
+  margin-bottom: 1.25rem;
+  font-weight: 600;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+h3 {
+  font-size: 1.1rem;
+  margin: 1rem 0 0.5rem;
+  font-weight: 600;
+}
+
+h3:first-child {
+  margin-top: 0;
+}
+
+.intro {
+  margin-bottom: 2.5rem;
+}
+
+.lead {
+  font-size: 1.125rem;
+  line-height: 1.7;
+  color: var(--text-muted);
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.feature-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.25rem;
+}
+
+.feature-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: var(--accent);
+}
+
+.feature-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.power-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.power-list li {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.power-list li:last-child {
+  border-bottom: none;
+}
+
+.generated-files ul,
+.repo-structure ul {
+  padding-left: 1.5rem;
+}
+
+.generated-files li,
+.repo-structure li {
+  margin-bottom: 0.5rem;
+}
+
+.steps {
+  padding-left: 1.5rem;
+}
+
+.steps li {
+  margin-bottom: 0.75rem;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code {
+  background: var(--bg-card);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.9em;
+  font-family: ui-monospace, monospace;
+}
+
+pre {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.875rem;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+.install-tabs {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+.install-block {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.25rem;
+}
+
+.install-block h3 {
+  margin-top: 0;
+}
+
+.install-block ol {
+  padding-left: 1.5rem;
+}
+
+.install-block li {
+  margin-bottom: 0.5rem;
+}
+
+.automation pre {
+  margin: 0.5rem 0 1rem;
+}
+
+.screenshot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.screenshot-grid figure {
+  margin: 0;
+  text-align: center;
+}
+
+.screenshot-grid img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+}
+
+.screenshot-grid figcaption {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+.companion p {
+  margin: 0;
+}
+
+.troubleshooting dl {
+  margin: 0;
+}
+
+.troubleshooting dt {
+  font-weight: 600;
+  margin-top: 1rem;
+  color: var(--text);
+}
+
+.troubleshooting dt:first-child {
+  margin-top: 0;
+}
+
+.troubleshooting dd {
+  margin: 0.25rem 0 0;
+  padding-left: 1rem;
+  color: var(--text-muted);
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 1rem;
+  border-top: 1px solid var(--border);
+}
+
+footer nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+footer a {
+  color: var(--text-muted);
+}
+
+footer a:hover {
+  color: var(--accent);
+}
+
+.copyright {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+@media (min-width: 640px) {
+  .hero-content h1 {
+    font-size: 2.5rem;
+  }
+
+  .feature-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .screenshot-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .feature-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .install-tabs {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .screenshot-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}


### PR DESCRIPTION
This pull request introduces a new static website for the project, adds automation for deployment to GitHub Pages, and provides scripts for local preview and site preparation. The main changes are grouped below:

Website creation and styling:

* Added a new `website/index.html` file containing a comprehensive landing page for GitSyncMarks, including features, installation instructions, screenshots, and troubleshooting.
* Added a new `website/styles.css` file with responsive and readable styling for the website.

Deployment automation:

* Added `.github/workflows/pages.yml` GitHub Actions workflow to automatically build and deploy the website and store assets to GitHub Pages when changes are pushed to `main`.

Local preview and preparation:

* Added `scripts/prepare-website.sh` to automate copying website and asset files into the `_site/` directory for deployment or local preview.
* Added a new npm script `website:preview` in `package.json` to prepare the site and serve it locally for preview.

Documentation update:

* Updated `README.md` to link to the new project website.