### PR TITLE
chore(release): v2.7.0 changelog, docs, Chrome/Firefox store descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- **Firefox — Sync History layout**: History rows use a single-row four-column grid (date, SHA, message, and an actions column with Preview + Restore or the “current” badge, right-aligned). A previous layout attempt let the actions column’s min-content width exceed the card so the Restore button could paint outside the card; card and list still use horizontal overflow containment as a safeguard.
-- **Options — Sync History SVG icons**: Preview, Restore, and current-commit SVG icons are now mounted via `DOMParser` + `replaceChildren` instead of `innerHTML`, eliminating security-linter warnings.
-
-### Changed
-- **package.json description**: Aligned with `extDescription` wording — uses “No server needed.” instead of “No middleman.” for consistency with all 12 locale files.
-
-### Added
-- **UI Density**: Three-level density setting (Compact / Medium / Large) via S / M / L selector in the options header. Applies to all extension surfaces (options, popup, search, Linkwarden save). Stored in `chrome.storage.sync` and synced across devices. CSS tokens in `ui-density.css` control typography, spacing, and control sizes globally.
-
-### Improved
-- **CSS architecture**: New root-level [`shared.css`](shared.css) holds the shared light/dark color palette (`--color-*`), universal reset, base `body` typography, `.btn` / `.btn-primary` / `.btn-secondary`, `@keyframes spin`, and `--focus-ring`. Extension pages load `ui-density.css` → `shared.css` → their page stylesheet to avoid duplicating theme tokens and button rules across options, popup, search, and Linkwarden save.
-- **Options header**: Language dropdown uses short codes (EN, DE, …) with full names on hover; density (S/M/L) and theme (Auto / Dark / Light) use matching segmented controls and uniform control height; theme uses inline SVG icons instead of a single cycle letter.
-- **Menu tab (visibility & order)**: Tighter list layout — smaller row padding, reduced gaps between rows and category headers, no extra row margin stacking with flex `gap`, slightly smaller labels/toggles/reorder buttons, and a smaller reset button top margin.
-- **Sync History (Settings)**: Column headers for date, commit hash, **Client** (device id parsed from GitSyncMarks commit subjects; full subject on hover), and a screen-reader **Actions** column. One grid row per commit so values align under headers; preview/restore icons sit in the last column. The active commit shows a checkmark icon plus the “current” label.
-- **What’s new (toolbar popup)**: Detects popup context (`whats-new-overlay--popup`), uses compact typography and four short bullets so the dialog usually fits without scrolling; Settings page keeps the larger panel.
-- **What’s new copy**: v2.7.0 bullets now focus on user-visible improvements (Sync History, restore/diff preview, duplicate fix, UI density & theme) and no longer mention CI internals.
-- **Store listings & screenshots**: All 12-language Chrome and Firefox store descriptions highlight Sync History, restore, and the duplicate fix. Screenshots regenerated with a new Sync History panel (slot 5, renumbering search through wizard to 6–11); meta checklists and README Visual Tour updated to match.
-
 ## [2.7.0] - 2026-03-28 (*Spock*)
 
 ### Changed
 - **CI**: CodeQL workflow uses `github/codeql-action` v4, runs JavaScript actions on Node 24 (`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`), and sets `CODEQL_ACTION_FILE_COVERAGE_ON_PRS` so PR analyses keep file coverage after GitHub’s April 2026 default change. The main CI workflow sets the same Node 24 opt-in for checkout/setup-node; optional Playwright jobs run smoke and options UI tests on push/PR to `main`.
+- **Extension short description (`extDescription`)**: Matches the ≤132-character Chrome Web Store summary from `store-assets/chrome-*.md` in all 12 locales; `package.json` `description` uses the English line so npm metadata stays aligned. Spanish and Polish store summaries were tightened by one word each (“Sinergia Linkwarden…”, “…i app…”) so the string stays within the 132-character store limit.
+- **Firefox manifest description**: `manifest.firefox.json` uses `__MSG_extDescriptionFirefox__`; each locale adds `extDescriptionFirefox` with the AMO summary from `store-assets/firefox-*.md` (up to 250 characters), separate from the Chrome-oriented `extDescription`.
 
 ### Fixed
 - **Duplicate folders (GitHub / toolbar)**: When the repo or browser had multiple sibling folders with the same display title (e.g. several “GitHubRepos (user)” or “Development” trees), serialization and `fileMapToBookmarkTree` now merge them into one logical folder so suffix paths (`development-2`, `githubrepos-user-3`, …) stop multiplying across syncs.
@@ -41,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Options page robustness**: Main tab switching guards missing `#tab-*` panels. The document-level folder-browser dismiss listener and folder UI no longer assume non-null nodes. Module-level `change`/`click` listeners use optional chaining so a missing control does not abort the rest of the options script.
 - **Build**: Unpacked Chrome/Firefox packages copy the `options/` directory so modular Settings scripts load correctly.
 - **push() / sync() error handling**: Removed dead `settings` reference in `push()` `catch`; hoisted `profileId` in `pull()`/`sync()` so `catch` can call `setSyncState` without `ReferenceError`.
+- **Firefox — Sync History layout**: History rows use a single-row four-column grid (date, SHA, message, and an actions column with Preview + Restore or the “current” badge, right-aligned). A previous layout attempt let the actions column’s min-content width exceed the card so the Restore button could paint outside the card; card and list still use horizontal overflow containment as a safeguard.
+- **Options — Sync History SVG icons**: Preview, Restore, and current-commit SVG icons are now mounted via `DOMParser` + `replaceChildren` instead of `innerHTML`, eliminating security-linter warnings.
 
 ### Improved
 - **Debug log performance**: Cached the debug-log enable flag in memory with a `storage.onChanged` listener, eliminating an async storage read on every `log()` call.
@@ -49,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Linkwarden screenshot delay**: Reduced the fixed 10-second screenshot upload delay to 5 seconds; now configurable via `screenshotDelayMs` constructor option.
 - **Theme listener cleanup**: Replaced deprecated `MediaQueryList.removeListener` with standard `removeEventListener`.
 - **CSS cleanup**: Removed dead `#tab-sync` selectors, merged duplicate `.context-menu-item-row` and `.btn-danger` rule blocks.
+- **CSS architecture**: New root-level [`shared.css`](shared.css) holds the shared light/dark color palette (`--color-*`), universal reset, base `body` typography, `.btn` / `.btn-primary` / `.btn-secondary`, `@keyframes spin`, and `--focus-ring`. Extension pages load `ui-density.css` → `shared.css` → their page stylesheet to avoid duplicating theme tokens and button rules across options, popup, search, and Linkwarden save.
+- **Options header**: Language dropdown uses short codes (EN, DE, …) with full names on hover; density (S/M/L) and theme (Auto / Dark / Light) use matching segmented controls and uniform control height; theme uses inline SVG icons instead of a single cycle letter.
+- **Menu tab (visibility & order)**: Tighter list layout — smaller row padding, reduced gaps between rows and category headers, no extra row margin stacking with flex `gap`, slightly smaller labels/toggles/reorder buttons, and a smaller reset button top margin.
+- **Sync History (Settings)**: Column headers for date, commit hash, **Client** (device id parsed from GitSyncMarks commit subjects; full subject on hover), and a screen-reader **Actions** column. One grid row per commit so values align under headers; preview/restore icons sit in the last column. The active commit shows a checkmark icon plus the “current” label.
+- **What’s new (toolbar popup)**: Detects popup context (`whats-new-overlay--popup`), uses compact typography and four short bullets so the dialog usually fits without scrolling; Settings page keeps the larger panel.
+- **What’s new copy**: v2.7.0 bullets now focus on user-visible improvements (Sync History, restore/diff preview, duplicate fix, UI density & theme) and no longer mention CI internals.
+- **Store listings & screenshots**: All 12-language Chrome and Firefox store descriptions highlight Sync History, restore, and the duplicate fix. Screenshots regenerated with a new Sync History panel (slot 5, renumbering search through wizard to 6–11); meta checklists and README Visual Tour updated to match.
 
 ### Removed
 - **Debug telemetry**: Removed `postAgentDebugLog` function and all call sites from `background.js` (hardcoded localhost POST leftover from debugging).
@@ -58,7 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **What's new after update**: After an extension update, a dismissible “What’s new” panel appears once when you open the toolbar popup or Settings (skipped on brand-new install so onboarding stays first).
 - **Sync history / rollback**: Browse recent sync commits in the Backup tab and restore bookmarks from any previous version. One-click "Undo last sync" reverts to the pre-sync state without navigating commit history.
 - **Diff preview**: "Preview" button on each history entry shows a structured diff (added, removed, changed bookmarks) before restoring, so users can make informed decisions. The preview opens inline under that commit; Added and Removed are shown side by side with collapsed sections by default. Each row also offers **Restore** using a two-click confirmation on the same button (label switches to “Click again to confirm”) instead of a browser dialog.
-- **Unit tests**: Expanded `test/` directory with `serializer.test.js` (slugify, shortHash, generateFilename, contentHash, bookmarkTreeToFileMap, fileMapToBookmarkTree, fileMapToMarkdown, fileMapToNetscapeHtml) and `sync-diff.test.js` (computeDiff, mergeDiffs). Total 54 tests covering serialization, deserialization, export, diff, and merge logic.
+- **Unit tests**: Expanded `test/` directory with `serializer.test.js` (slugify, shortHash, generateFilename, contentHash, bookmarkTreeToFileMap, fileMapToBookmarkTree, fileMapToMarkdown, fileMapToNetscapeHtml) and `sync-diff.test.js` (computeDiff, mergeDiffs), plus additional suites (`sync-commit-message`, `merge-order`, `dedupe`, `whats-new`). Total 65 tests covering serialization, deserialization, export, diff, merge, and related helpers.
+- **UI Density**: Three-level density setting (Compact / Medium / Large) via S / M / L selector in the options header. Applies to all extension surfaces (options, popup, search, Linkwarden save). Stored in `chrome.storage.sync` and synced across devices. CSS tokens in `ui-density.css` control typography, spacing, and control sizes globally.
 
 ## [2.6.2] - 2026-03-08 (*Link*)
 

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "Deine Lesezeichen, sicher auf GitHub — Einzeldatei-Speicherung, Drei-Wege-Merge, funktioniert mit Chrome & Firefox. Kein Server nötig."
+    "message": "Lesezeichen-Sync via GitHub. Linkwarden-Synergie, Smart Search und Companion App. Direkt, sicher, privat."
+  },
+  "extDescriptionFirefox": {
+    "message": "Lesezeichen-Sync via GitHub. Linkwarden-Synergie, Smart Search und geführter Setup-Wizard. Bidirektional, sicher und privat. Volle Firefox-Unterstützung inklusive nativer Menü-Struktur. Kein Mittelsmann."
   },
   "commands_quickSync": {
     "message": "Lesezeichen sofort synchronisieren"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "Your bookmarks, safe on GitHub — per-file storage, three-way merge sync, works on Chrome & Firefox. No server needed."
+    "message": "Bookmark sync via GitHub. Linkwarden synergy, Smart Search, and Companion App. Direct, secure, private."
+  },
+  "extDescriptionFirefox": {
+    "message": "Bookmark sync via GitHub. Linkwarden synergy, Smart Search, and guided setup wizard. Bidirectional, secure, and private. Full Firefox support. No middleman."
   },
   "commands_quickSync": {
     "message": "Quick sync bookmarks"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "Tus marcadores seguros en GitHub — almacenamiento por archivo, sincronización de fusión triple, funciona con Chrome y Firefox. Sin servidor."
+    "message": "Sincronización de marcadores vía GitHub. Sinergia Linkwarden, búsqueda inteligente y app complementaria. Directo, seguro y privado."
+  },
+  "extDescriptionFirefox": {
+    "message": "Sincronización de marcadores vía GitHub. Sinergia Linkwarden, búsqueda inteligente y asistente de configuración. Bidireccional y seguro. Soporte nativo de Firefox."
   },
   "commands_quickSync": {
     "message": "Sincronizar marcadores rápidamente"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "Vos favoris en sécurité sur GitHub — stockage par fichier, synchronisation à fusion triple, fonctionne avec Chrome et Firefox. Pas de serveur requis."
+    "message": "Synchro de favoris via GitHub. Synergie Linkwarden, recherche intelligente et application mobile. Direct, sécurisé, privé."
+  },
+  "extDescriptionFirefox": {
+    "message": "Synchro de favoris via GitHub. Synergie Linkwarden, recherche intelligente et assistant de config. Bidirectionnel, sécurisé, privé. Support Firefox natif."
   },
   "commands_quickSync": {
     "message": "Synchroniser les favoris rapidement"

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "I tuoi segnalibri, al sicuro su GitHub — archiviazione per file, sincronizzazione con merge a tre vie, funziona su Chrome e Firefox. Nessun server necessario."
+    "message": "Sincronizzazione segnalibri via GitHub. Sinergia Linkwarden, ricerca intelligente e Companion App. Diretto, sicuro, privato."
+  },
+  "extDescriptionFirefox": {
+    "message": "Sincronizzazione segnalibri via GitHub. Sinergia Linkwarden, ricerca veloce e configurazione guidata. Sicuro e privato. Supporto Firefox nativo."
   },
   "commands_quickSync": {
     "message": "Sincronizzazione rapida segnalibri"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "ブックマークをGitHubに安全に保存 — ファイル単位の保存、三方向マージ同期、Chrome・Firefox対応。サーバー不要。"
+    "message": "GitHub経由のブックマーク同期。Linkwarden連携、スマート検索、コンパニオンアプリ付。直接、安全、プライベート。"
+  },
+  "extDescriptionFirefox": {
+    "message": "GitHub経由のブックマーク同期。Linkwarden連携、スマート検索、セットアップウィザード。双方向同期可能でFirefoxメニューにもネイティブ対応。"
   },
   "commands_quickSync": {
     "message": "ブックマークをクイック同期"

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "북마크를 GitHub에 안전하게 보관 — 파일별 저장, 3방향 병합 동기화, Chrome 및 Firefox 지원. 서버 불필요."
+    "message": "GitHub를 통한 북마크 동기화. Linkwarden 연동, 스마트 검색 및 모바일 앱 제공. 매우 안전하고 프라이빗합니다."
+  },
+  "extDescriptionFirefox": {
+    "message": "GitHub 북마크 동기화. Linkwarden 연동, 스마트 검색 및 설정 마법사. 중간 서버 없이 완벽하게 독립적으로 Firefox 지원."
   },
   "commands_quickSync": {
     "message": "북마크 빠른 동기화"

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "Twoje zakładki, bezpiecznie na GitHub — przechowywanie w osobnych plikach, trójstronne scalanie, działa w Chrome i Firefox. Bez serwera."
+    "message": "Synchronizacja zakładek przez GitHub. Synergia z Linkwarden, inteligentne wyszukiwanie i app. Bezpośrednio i bezpiecznie."
+  },
+  "extDescriptionFirefox": {
+    "message": "Synchronizacja zakładek przez GitHub. Synergia Linkwarden, wyszukiwanie i kreator konfiguracji. Bezpośrednio, bezpiecznie. Wsparcie dla Firefox."
   },
   "commands_quickSync": {
     "message": "Szybka synchronizacja zakładek"

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "Seus favoritos, seguros no GitHub — armazenamento por arquivo, sincronização com merge de três vias, funciona no Chrome e Firefox. Sem necessidade de servidor."
+    "message": "Sincronização de favoritos via GitHub. Sinergia com Linkwarden, Smart Search e app complementar. Direto, seguro, privado."
+  },
+  "extDescriptionFirefox": {
+    "message": "Sincronização de favoritos via GitHub. Sinergia Linkwarden, Smart Search e assistente de configuração. Seguro e privado. Suporte nativo ao Firefox."
   },
   "commands_quickSync": {
     "message": "Sincronização rápida dos favoritos"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "Ваши закладки в безопасности на GitHub — хранение по файлам, трёхсторонняя синхронизация с объединением, работает в Chrome и Firefox. Сервер не нужен."
+    "message": "Синхронизация закладок через GitHub. Интеграция с Linkwarden, Smart Search и приложение-компаньон. Напрямую, безопасно, приватно."
+  },
+  "extDescriptionFirefox": {
+    "message": "Синхронизация закладок через GitHub. Интеграция Linkwarden, умный поиск и мастер настройки. Безопасно, приватно. Полная поддержка Firefox."
   },
   "commands_quickSync": {
     "message": "Быстрая синхронизация закладок"

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "Yer işaretleriniz GitHub'da güvende — dosya bazlı depolama, üç yönlü birleştirme senkronizasyonu, Chrome ve Firefox'ta çalışır. Sunucu gerekmez."
+    "message": "GitHub üzerinden yer imi senkronizasyonu. Linkwarden sinerjisi, Akıllı Arama ve Yardımcı Uygulama. Doğrudan, güvenli ve özel."
+  },
+  "extDescriptionFirefox": {
+    "message": "GitHub üzerinden yer imi senkronizasyonu. Linkwarden sinerjisi, Akıllı Arama ve rehberli kurulum. Tamamen özel. Özgün Firefox desteği."
   },
   "commands_quickSync": {
     "message": "Yer işaretlerini hızlı senkronize et"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -3,7 +3,10 @@
     "message": "GitSyncMarks"
   },
   "extDescription": {
-    "message": "书签安全存储在 GitHub — 按文件存储、三方合并同步，支持 Chrome 和 Firefox。无需服务器。"
+    "message": "通过GitHub同步书签。支持Linkwarden、智能搜索和配套应用。双向、安全且绝对私密。"
+  },
+  "extDescriptionFirefox": {
+    "message": "通过GitHub同步书签。支持Linkwarden、智能搜索与设置向导。无第三方服务器中转，原生支持Firefox结构。"
   },
   "commands_quickSync": {
     "message": "快速同步书签"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,6 +61,7 @@ Extension metadata. Two manifests for browser-specific differences:
 
 | Field | Chrome | Firefox |
 |---|---|---|
+| `description` | `__MSG_extDescription__` | `__MSG_extDescriptionFirefox__` |
 | Background | `service_worker: "background.js"` | `scripts: ["background.js"]` |
 | Browser-specific | — | `browser_specific_settings.gecko` |
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -40,7 +40,7 @@ The version is declared in `manifest.json` → `"version"`. It must match `manif
 
 | Version | Codename | Description |
 |---|---|---|
-| `2.7.0` | *Spock* | Sync history & rollback + diff preview; duplicate folder merge (serializer + tree restore); options UI/i18n/build fixes; What’s new panel after update; CI CodeQL v4 / Node 24, lint + E2E smoke; modular options + 54 unit tests |
+| `2.7.0` | *Spock* | Sync history & rollback + diff preview; duplicate folder merge; options modularization + Sync History layout/SVG hardening; UI density (S/M/L) + shared CSS; What’s new (popup + copy); store listings/screenshots refresh; `extDescription` aligned with Chrome store summaries (12 locales) and `extDescriptionFirefox` with AMO summaries; package.json description match; CI CodeQL v4 / Node 24; 65 unit tests |
 | `2.6.0` | *Link* | Linkwarden integration; Smart Search; Onboarding Wizard; switched to Bearer authentication; support for Fine-grained PATs and GitHub Apps |
 | `2.5.3` | *Cortana* | Context menu productivity update: pinned quick folders (up to 3), Search Bookmarks entry opens a dedicated search popup, Open All from Folder with safety confirmation threshold; Files -> Settings adds context-menu tools |
 | `2.5.2` | *Cortana* | Fix: orphan subfolders in generated files (README, bookmarks.html, feed.xml, dashy-conf.yml); website layout unified; Docs removed from quick-nav; README load-from-source section; Settings sync UI: buttons disabled until client name set, password saved after Import/Sync/Create, layout (Client name + Create in one row; Refresh + Dropdown + Import + Sync in one row); Help Getting Started: Start setup wizard button |

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extName__",
   "short_name": "GitSyncMarks",
   "version": "2.7.0",
-  "description": "__MSG_extDescription__",
+  "description": "__MSG_extDescriptionFirefox__",
   "default_locale": "en",
   "homepage_url": "https://gitsyncmarks.com",
   "browser_specific_settings": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitsyncmarks",
   "version": "2.7.0",
   "private": true,
-  "description": "Your bookmarks, safe on GitHub — per-file storage, three-way merge sync, works on Chrome & Firefox. No server needed.",
+  "description": "Bookmark sync via GitHub. Linkwarden synergy, Smart Search, and Companion App. Direct, secure, private.",
   "scripts": {
     "build": "bash scripts/build.sh",
     "build:chrome": "bash scripts/build.sh chrome",

--- a/store-assets/chrome-es.md
+++ b/store-assets/chrome-es.md
@@ -5,7 +5,7 @@
 GitSyncMarks
 
 ### Summary (max 132 characters)
-Sincronización de marcadores vía GitHub. Sinergia con Linkwarden, búsqueda inteligente y app complementaria. Directo, seguro y privado.
+Sincronización de marcadores vía GitHub. Sinergia Linkwarden, búsqueda inteligente y app complementaria. Directo, seguro y privado.
 
 ### Detailed Description
 GitSyncMarks es una solución profesional para sincronizar bidireccional y automáticamente sus marcadores con un repositorio de GitHub. Gestione sus datos en el escritorio con Chrome y Firefox, o dispositivos móviles con la aplicación complementaria. Sin intermediarios, sin servidores de terceros: control total y privacidad.

--- a/store-assets/chrome-pl.md
+++ b/store-assets/chrome-pl.md
@@ -5,7 +5,7 @@
 GitSyncMarks
 
 ### Summary (max 132 characters)
-Synchronizacja zakładek przez GitHub. Synergia z Linkwarden, inteligentne wyszukiwanie i aplikacja mobilna. Bezpośrednio i bezpiecznie.
+Synchronizacja zakładek przez GitHub. Synergia z Linkwarden, inteligentne wyszukiwanie i app. Bezpośrednio i bezpiecznie.
 
 ### Detailed Description
 GitSyncMarks to profesjonalne rozwiązanie do dwukierunkowej i automatycznej synchronizacji zakładek z repozytorium GitHub. Pełna kontrola nad danymi i całkowita prywatność – bez pośredników i bez serwerów stron trzecich.


### PR DESCRIPTION
## Summary
- Merges all items that were under `[Unreleased]` into **2.7.0** in `CHANGELOG.md` (UI density, shared CSS, Sync History polish, store assets, `extDescription` / `extDescriptionFirefox`, etc.).
- Updates `docs/RELEASE.md` version history and `docs/ARCHITECTURE.md` (dual manifest description keys).
- Locales + `manifest.firefox.json` + `package.json` + Chrome ES/PL store lines as committed.

## After merge
Maintainer should delete and recreate tag `v2.7.0` on the new `main` tip if the GitHub Release should point at this commit.

## Verification
- `npm run test:unit`
- `npm run build`