### PR TITLE
fix: layered tree uploads to avoid rate limits on large pushes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 # Copy to .env and fill in values. .env is gitignored.
 #
 # Create the test repo once: GITSYNCMARKS_TEST_PAT=ghp_xxx node scripts/create-test-repo.js
+#
+# npm run test:onboarding-scale uses --ensure-repo: deletes GITSYNCMARKS_TEST_REPO if it exists,
+# then recreates it. Classic PATs need the delete_repo scope; fine-grained tokens need
+# Administration: delete + create on that repository (or use a dedicated disposable repo name).
 
 GITSYNCMARKS_TEST_PAT=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 GITSYNCMARKS_TEST_REPO_OWNER=your-github-username

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] - 2026-03-28 (*Spock*)
+
+### Improved
+- **Onboarding / large-repo diagnostic**: `scripts/test-onboarding-rate-limit.js` adds `--parallel-only` and `--sequential-only` (single API pass). Default two-pass mode warns when simulating very large bookmark counts. New `npm run test:onboarding-scale` entry point; `e2e/README.md` documents simulating ~5000 bookmarks against a disposable GitHub repo.
+- **`npm run test:onboarding-scale` provisions the repo**: passes `--ensure-repo` — **DELETE** `GITSYNCMARKS_TEST_REPO` if it exists, then **POST /user/repos** (or org equivalent) to recreate it. Override with `--no-ensure-repo`. Classic PATs need **`delete_repo`**; see `.env.example` and `e2e/README.md`.
+- **`npm run verify-test-repo`**: reads `main`’s recursive git tree via the GitHub API, prints blob count, checks required `bookmarks/` layout, optional `--min-bookmarks N` and `--verbose` (`scripts/verify-test-repo.js`, `e2e/README.md`).
+
+### Fixed
+- **`test-onboarding-rate-limit.js --reset`**: Repo reset uses a single commit whose tree is Git’s canonical empty tree (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`), avoiding `422 GitRPC::BadObjectState` and failed chunked deletes on large bookmark trees.
+- **Large pushes / onboarding speed & secondary rate limits**: `atomicCommit` no longer issues one `POST /git/blobs` per file. New/changed files are sent as **`content` on `POST /git/trees`** in layered batches (`lib/github-tree-batch.js`, max ~400 entries or ~28 MiB per request). GitHub creates blobs server-side, so a ~5000-file first push is ~13 tree calls plus commit/ref instead of ~5000 blob calls — much faster and far less likely to hit secondary limits. The onboarding diagnostic script’s `--parallel-only` path matches this behavior (`docs/SYNC-LOGIC.md`, `e2e/README.md`, `docs/ARCHITECTURE.md`).
+
 ## [2.7.0] - 2026-03-28 (*Spock*)
 
 ### Changed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -127,7 +127,7 @@ Wraps both the **Contents API** (legacy, used for migration/validation) and the 
 | `getCommit()` / `getTree()` / `getBlob()` | Git Data | Read commit, tree, file content |
 | `createBlob()` / `createTree()` / `createCommit()` | Git Data | Build new commit |
 | `updateRef()` / `createRef()` | Git Data | Update or create branch |
-| `atomicCommit(message, fileChanges)` | Git Data | All-in-one: atomic multi-file commit |
+| `atomicCommit(message, fileChanges)` | Git Data | Atomic multi-file commit via layered `POST /git/trees` with inline `content` (`lib/github-tree-batch.js`) |
 | `listCommits({ path, perPage })` | REST | List recent commits, optionally filtered by path |
 
 ### `lib/bookmark-serializer.js` — Serializer
@@ -276,6 +276,7 @@ GitSyncMarks/
 │   ├── sync-commit-message.js    # Parse commit subject → client id (history UI)
 │   ├── sync-migration.js         # Legacy format migration
 │   ├── github-api.js             # GitHub REST + Git Data API
+│   ├── github-tree-batch.js      # Chunk file changes for tree API (inline blob content)
 │   ├── bookmark-serializer.js    # Per-file bookmark conversion
 │   ├── bookmark-replace.js       # Replace local bookmarks
 │   ├── github-repos.js           # GitHub Repos folder
@@ -306,7 +307,8 @@ GitSyncMarks/
 │   ├── generate-screenshots.js   # Auto-generate store screenshots
 │   ├── fetch-app-content.sh      # Fetch App README, assets
 │   ├── build-docs.js             # Markdown → HTML for docs/
-│   └── build-index.js            # Build index.html
+│   ├── build-index.js            # Build index.html
+│   └── verify-test-repo.js       # Verify bookmark files in GitHub test repo (API)
 ├── package.json                  # npm scripts for building
 ├── .github/workflows/
 │   ├── test-e2e.yml              # E2E tests (manual trigger only)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -40,6 +40,7 @@ The version is declared in `manifest.json` → `"version"`. It must match `manif
 
 | Version | Codename | Description |
 |---|---|---|
+| `2.7.1` | *Spock* | Fix: layered tree uploads with inline content for atomicCommit — avoids secondary rate limits on large first pushes (e.g. 5 000 bookmarks); onboarding diagnostic tooling (test:onboarding-scale, verify-test-repo) |
 | `2.7.0` | *Spock* | Sync history & rollback + diff preview; duplicate folder merge; options modularization + Sync History layout/SVG hardening; UI density (S/M/L) + shared CSS; What’s new (popup + copy); store listings/screenshots refresh; `extDescription` aligned with Chrome store summaries (12 locales) and `extDescriptionFirefox` with AMO summaries; package.json description match; CI CodeQL v4 / Node 24; 65 unit tests |
 | `2.6.0` | *Link* | Linkwarden integration; Smart Search; Onboarding Wizard; switched to Bearer authentication; support for Fine-grained PATs and GitHub Apps |
 | `2.5.3` | *Cortana* | Context menu productivity update: pinned quick folders (up to 3), Search Bookmarks entry opens a dedicated search popup, Open All from Folder with safety confirmation threshold; Files -> Settings adds context-menu tools |

--- a/docs/SYNC-LOGIC.md
+++ b/docs/SYNC-LOGIC.md
@@ -227,7 +227,9 @@ GitHub API requests use `cache: no-store` to reduce cache-related staleness.
 
 In the common case (few files changed), this is 3 + N calls where N is the number of changed files.
 
-**Blob GET concurrency:** `getBlob` requests run in batches of five parallel calls (not all at once). Large repositories (hundreds of bookmarks) previously issued one concurrent request per file; GitHub’s secondary rate limits treat that as abusive. Batching matches the upload-side concurrency used in `atomicCommit`.
+**Blob GET concurrency:** `getBlob` requests run in batches of five parallel calls (not all at once). Large repositories (hundreds of bookmarks) previously issued one concurrent request per file; GitHub’s secondary rate limits treat that as abusive.
+
+**Blob POST (upload) via trees:** `atomicCommit` does **not** call `POST /git/blobs` per file. Each changed file is included in `POST /git/trees` with a `content` field; GitHub creates blobs server-side. Batches are split by entry count (~400) and approximate JSON size (`lib/github-tree-batch.js`) so each tree request stays within GitHub payload limits; multiple tree calls are chained with `base_tree` until the full change set is applied, then one commit and ref update.
 
 **History / pinned commit:** `fetchRemoteFileMapAtCommit()` uses the same batched blob fetch. A small in-memory cache (few entries, short TTL) deduplicates work when preview and restore target the same commit SHA in quick succession.
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,6 +28,35 @@ Sync tests require a private GitHub repo and a Personal Access Token.
    npm run test:e2e:sync
    ```
 
+## Large onboarding simulation (many bookmarks → GitHub API)
+
+This is **not** a Playwright test: it drives the same Git Data API flow as an initial push (`createBlob` × N, `createTree`, `createCommit`, update/create ref). Use a **dedicated disposable repo name** in `GITSYNCMARKS_TEST_REPO` plus the same env vars as sync tests.
+
+**`npm run test:onboarding-scale`** passes **`--ensure-repo`**: it **deletes** that repository if it already exists, then **creates** it again (private, `auto_init`). Your PAT needs permission to delete the repo (classic: **`delete_repo`** scope). To keep an existing repo:  
+`npm run test:onboarding-scale -- --no-ensure-repo …` or use `npm run test:rate-limit` / `node scripts/test-onboarding-rate-limit.js` without `--ensure-repo`.
+
+- **~5000 bookmarks** ≈ ~5003 JSON files → extension-style push uses **layered `POST /git/trees`** with inline `content` (~13 tree calls + commit + ref for 5003 files), not thousands of `POST /git/blobs`. The default PAT hourly limit (**5000** REST calls) is usually sufficient for one such push; use `--parallel-only` for a **single** pass at that scale (avoid default two-pass mode).
+- **Secondary rate limits:** Still possible with extreme traffic; the tree-based path is much less bursty than per-blob uploads. If GitHub returns **403** secondary limit, wait a few minutes and retry.
+- Reproducing the **old** per-blob bottleneck: `--sequential-only`.
+- Matching **current extension** behavior (layered trees + inline content): `--parallel-only`.
+
+```bash
+# Empty the test repo, then simulate first push with 5000 bookmarks (extension-style)
+GITSYNCMARKS_TEST_PAT=… GITSYNCMARKS_TEST_REPO_OWNER=… GITSYNCMARKS_TEST_REPO=… \
+  npm run test:onboarding-scale -- --bookmark-count 5000 --reset --parallel-only
+```
+
+Optional flags: `--ensure-repo` / `--no-ensure-repo`, `--sequential-only`, `--no-color`. See `scripts/test-onboarding-rate-limit.js`.
+
+### Verify test repo contents (GitHub API)
+
+Lists all blobs on `main` and checks that the minimal GitSyncMarks paths exist (`bookmarks/_index.json`, `toolbar/_order.json`, `other/_order.json`). Optional: require a minimum number of toolbar bookmark JSON files (after onboarding-scale with `--bookmark-count 5000`, use `--min-bookmarks 5000`).
+
+```bash
+GITSYNCMARKS_TEST_PAT=… GITSYNCMARKS_TEST_REPO_OWNER=… GITSYNCMARKS_TEST_REPO=… \
+  npm run verify-test-repo -- --verbose --min-bookmarks 5000
+```
+
 ## CI (GitHub Actions)
 
 **E2E in CI is currently disabled** (see [ROADMAP.md](../ROADMAP.md) backlog). Tests run **locally only**. The E2E workflow (`.github/workflows/test-e2e.yml`) can be triggered manually via Actions → E2E Tests → Run workflow. The release workflow no longer runs E2E.

--- a/lib/github-api.js
+++ b/lib/github-api.js
@@ -5,6 +5,7 @@
  */
 
 import { getMessage } from './i18n.js';
+import { chunkAtomicCommitTreeBatches } from './github-tree-batch.js';
 
 const API_BASE = 'https://api.github.com';
 
@@ -370,7 +371,8 @@ export class GitHubAPI {
    * Each item can add/modify (mode + type + sha) or delete (sha = null) a file.
    *
    * @param {string|null} baseTreeSha - Base tree SHA for incremental update (null for full tree)
-   * @param {Array<{path: string, mode: string, type: string, sha: string|null}>} items
+   * @param {Array<{path: string, mode: string, type: string, sha?: string|null, content?: string}>} items
+   *   Use `content` for new data (GitHub creates the blob) or `sha` for an existing blob; `sha: null` deletes.
    * @returns {Promise<string>} SHA of the new tree
    */
   async createTree(baseTreeSha, items) {
@@ -389,6 +391,21 @@ export class GitHubAPI {
     }
     const data = await response.json();
     return data.sha;
+  }
+
+  /**
+   * Apply tree batches on top of base_tree (or null for a fresh tree). Each batch is one POST /git/trees.
+   *
+   * @param {string|null} baseTreeSha
+   * @param {Array<Array<{path: string, mode: string, type: string, sha?: null, content?: string}>>} batches
+   * @returns {Promise<string>} Final tree SHA
+   */
+  async buildLayeredTree(baseTreeSha, batches) {
+    let sha = baseTreeSha;
+    for (const batch of batches) {
+      sha = await this.createTree(sha, batch);
+    }
+    return /** @type {string} */ (sha);
   }
 
   /**
@@ -476,7 +493,8 @@ export class GitHubAPI {
 
   /**
    * Perform an atomic multi-file commit using the Git Data API.
-   * Creates blobs, a new tree, a commit, and updates the branch ref.
+   * Builds trees with inline `content` on upload entries (GitHub creates blobs server-side), in layered
+   * batches to respect payload limits — avoids thousands of POST /git/blobs and secondary rate limits (#51).
    * Handles empty repos (no existing branch/commit) by creating the initial commit.
    *
    * @param {string} message - Commit message
@@ -486,7 +504,7 @@ export class GitHubAPI {
   async atomicCommit(message, fileChanges) {
     const commitOnExistingBranch = async (baseTreeSha, parentSha) => {
       for (let attempt = 0; attempt < 3; attempt++) {
-        const newTreeSha = await this.createTree(baseTreeSha, treeItems);
+        const newTreeSha = await this.buildLayeredTree(baseTreeSha, batches);
         const newCommitSha = await this.createCommit(message, newTreeSha, parentSha);
         try {
           await this.updateRef(newCommitSha);
@@ -532,11 +550,7 @@ export class GitHubAPI {
       }
     }
 
-    // 2. Create blobs for new/modified files.
-    // Blobs are created in parallel batches (concurrency = 5) to avoid the
-    // sequential bottleneck that caused GitHub secondary rate-limit errors
-    // during onboarding with large bookmark collections (issue #51).
-    const BLOB_CONCURRENCY = 5;
+    // 2. Layered trees: deletions (sha null) + uploads (inline content → GitHub creates blobs).
     const deletions = [];
     const uploads = []; // { path, content }
 
@@ -548,26 +562,16 @@ export class GitHubAPI {
       }
     }
 
-    const treeItems = deletions.map(path => ({ path, mode: '100644', type: 'blob', sha: null }));
-
-    for (let i = 0; i < uploads.length; i += BLOB_CONCURRENCY) {
-      const batch = uploads.slice(i, i + BLOB_CONCURRENCY);
-      const settled = await Promise.all(
-        batch.map(({ path, content }) =>
-          this.createBlob(content).then(sha => ({ path, mode: '100644', type: 'blob', sha }))
-        )
-      );
-      treeItems.push(...settled);
-    }
-
-    if (treeItems.length === 0) {
+    if (deletions.length === 0 && uploads.length === 0) {
       return currentCommitSha; // Nothing to commit
     }
 
-    // 3–5. Create tree, commit, and update ref (with retry on non-fast-forward)
+    const batches = chunkAtomicCommitTreeBatches(deletions, uploads);
+
+    // 3–5. Create tree layer(s), commit, and update ref (with retry on non-fast-forward)
     if (isEmptyRepo) {
       for (let attempt = 0; attempt < 4; attempt++) {
-        const newTreeSha = await this.createTree(null, treeItems);
+        const newTreeSha = await this.buildLayeredTree(null, batches);
         const newCommitSha = await this.createCommit(message, newTreeSha, null);
         try {
           await this.createRef(newCommitSha);

--- a/lib/github-tree-batch.js
+++ b/lib/github-tree-batch.js
@@ -1,0 +1,64 @@
+/**
+ * Split atomic-commit file changes into batches for POST /git/trees.
+ * Upload entries use `content` so GitHub creates blobs server-side (no per-file POST /git/blobs).
+ *
+ * Used by {@link GitHubAPI#atomicCommit} and onboarding diagnostics.
+ */
+
+/** @typedef {{ path: string, content: string }} UploadEntry */
+
+/** Max tree entries per POST /git/trees (stay under payload / server limits). */
+export const ATOMIC_COMMIT_TREE_BATCH_MAX_ENTRIES = 400;
+
+/** Rough UTF-8 byte budget per layered tree request (GitHub tree bodies are capped ~40 MiB). */
+export const ATOMIC_COMMIT_TREE_BATCH_MAX_BYTES = 28 * 1024 * 1024;
+
+/**
+ * @param {string[]} deletions
+ * @param {UploadEntry[]} uploads
+ * @returns {Array<Array<{path: string, mode: string, type: string, sha?: null, content?: string}>>}
+ */
+export function chunkAtomicCommitTreeBatches(deletions, uploads) {
+  const encoder = new TextEncoder();
+  /** @type {Array<Array<{path: string, mode: string, type: string, sha?: null, content?: string}>>} */
+  const batches = [];
+  /** @type {Array<{path: string, mode: string, type: string, sha?: null, content?: string}>} */
+  let batch = [];
+  let approxBytes = 0;
+
+  const flush = () => {
+    if (batch.length) {
+      batches.push(batch);
+      batch = [];
+      approxBytes = 0;
+    }
+  };
+
+  const approxItemBytes = (item) => {
+    let n = 64 + item.path.length * 2;
+    if (item.content !== undefined) {
+      n += encoder.encode(item.content).length;
+    }
+    return n;
+  };
+
+  const push = (item) => {
+    const ib = approxItemBytes(item);
+    if (batch.length > 0 &&
+        (batch.length >= ATOMIC_COMMIT_TREE_BATCH_MAX_ENTRIES ||
+          approxBytes + ib > ATOMIC_COMMIT_TREE_BATCH_MAX_BYTES)) {
+      flush();
+    }
+    batch.push(item);
+    approxBytes += ib;
+  };
+
+  for (const path of deletions) {
+    push({ path, mode: '100644', type: 'blob', sha: null });
+  }
+  for (const { path, content } of uploads) {
+    push({ path, mode: '100644', type: 'blob', content });
+  }
+  flush();
+  return batches;
+}

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "GitSyncMarks",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "__MSG_extDescriptionFirefox__",
   "default_locale": "en",
   "homepage_url": "https://gitsyncmarks.com",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "GitSyncMarks",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "homepage_url": "https://gitsyncmarks.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitsyncmarks",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "description": "Bookmark sync via GitHub. Linkwarden synergy, Smart Search, and Companion App. Direct, secure, private.",
   "scripts": {
@@ -20,6 +20,8 @@
     "cleanup:e2e-repos": "node scripts/cleanup-e2e-repos.js",
     "test:rate-limit": "node scripts/test-onboarding-rate-limit.js",
     "test:rate-limit:reset": "node scripts/test-onboarding-rate-limit.js --reset",
+    "test:onboarding-scale": "node scripts/test-onboarding-rate-limit.js --ensure-repo",
+    "verify-test-repo": "node scripts/verify-test-repo.js",
     "website:preview": "bash scripts/prepare-website.sh && npx --yes serve _site -p 3000"
   },
   "devDependencies": {

--- a/scripts/test-onboarding-rate-limit.js
+++ b/scripts/test-onboarding-rate-limit.js
@@ -15,24 +15,36 @@
  *   node scripts/test-onboarding-rate-limit.js [--bookmark-count 50] [--reset]
  *
  * OPTIONS:
+ *   --ensure-repo        DELETE the repo if it exists, then CREATE it (npm run test:onboarding-scale passes this by default)
+ *   --no-ensure-repo     Skip delete/create even when the npm script adds --ensure-repo
  *   --bookmark-count N   Number of synthetic bookmarks to simulate (default: 50)
  *   --reset              Delete all content from the repo before the test (fresh start)
+ *   --parallel-only      Run only the extension-style path: layered POST /git/trees with inline file content (~few calls per 400 files)
+ *   --sequential-only    Run only the sequential POST /git/blobs strategy (reproduces pre-#51 bottleneck)
  *   --no-color           Disable color output
  *
+ * Large collections (e.g. 5000 bookmarks ≈ 5003 files → ~5006 API calls per pass):
+ *   Use --parallel-only (or --sequential-only) so you do not run two full passes and burn ~10k calls
+ *   against the hourly REST limit (5000 for standard PAT).
+ *
  * WHAT IT DOES:
+ *   0. With --ensure-repo: DELETE repo if it exists, then CREATE a fresh private repo (same name as GITSYNCMARKS_TEST_REPO)
  *   1. Checks current rate-limit headroom
- *   2. Optionally resets the repo to empty (--reset)
+ *   2. Optionally resets the repo to empty (--reset; one commit to Git’s canonical empty tree)
  *   3. Simulates generating N bookmark files (like the onboarding push would)
- *   4. Runs the atomic commit flow (createBlob × N, createTree, createCommit, updateRef/createRef)
+ *   4. Runs the atomic commit flow (sequential: createBlob × N; extension-style: layered createTree + content, commit, ref)
  *   5. Reports: calls made, rate-limit consumed, time taken, success/failure
  *
  * REQUIREMENTS:
  *   - Node.js 18+ (native fetch)
- *   - PAT with `repo` scope
- *   - The repo must already exist (create with: node scripts/create-test-repo.js)
+ *   - PAT with `repo` scope; `--ensure-repo` also needs **`delete_repo`** on classic PATs (or equivalent on fine-grained tokens)
+ *   - Without `--ensure-repo`, the repo must already exist (see node scripts/create-test-repo.js)
  */
 
 'use strict';
+
+const path = require('path');
+const { pathToFileURL } = require('url');
 
 const API_BASE = 'https://api.github.com';
 
@@ -43,7 +55,15 @@ const bookmarkCount = (() => {
     return idx !== -1 ? parseInt(args[idx + 1], 10) || 50 : 50;
 })();
 const doReset = args.includes('--reset');
+const ensureRepo = args.includes('--ensure-repo') && !args.includes('--no-ensure-repo');
 const noColor = args.includes('--no-color');
+const parallelOnly = args.includes('--parallel-only');
+const sequentialOnly = args.includes('--sequential-only');
+if (parallelOnly && sequentialOnly) {
+    console.error('Use only one of --parallel-only or --sequential-only.');
+    process.exit(1);
+}
+const strategy = sequentialOnly ? 'sequential' : parallelOnly ? 'parallel' : 'both';
 
 // ---- Color helpers ----
 const c = {
@@ -80,27 +100,32 @@ function getEnv() {
             '  GITSYNCMARKS_TEST_REPO_OWNER=your-username\n' +
             '  GITSYNCMARKS_TEST_REPO=empty-repo-name\n\n' +
             'Create the repo first:\n' +
-            '  node scripts/create-test-repo.js\n'
+            '  node scripts/create-test-repo.js\n' +
+            'Or run with --ensure-repo (needs delete_repo on the PAT).\n'
         );
         process.exit(1);
     }
     return { token, owner, repo };
 }
 
-async function ghFetch(url, options = {}) {
+async function githubCountedFetch(url, options = {}) {
     const { token } = getEnv();
     const label = `${options.method || 'GET'} ${url.replace(API_BASE, '')}`;
     const t0 = Date.now();
 
+    const headers = {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...options.headers,
+    };
+    if (options.body !== undefined) {
+        headers['Content-Type'] = 'application/json';
+    }
+
     const res = await fetch(url, {
         ...options,
-        headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: 'application/vnd.github+json',
-            'Content-Type': 'application/json',
-            'X-GitHub-Api-Version': '2022-11-28',
-            ...options.headers,
-        },
+        headers,
     });
 
     totalCalls++;
@@ -144,6 +169,71 @@ async function ghFetch(url, options = {}) {
     return res.json();
 }
 
+async function ghFetch(url, options = {}) {
+    return githubCountedFetch(url, options);
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Delete GITSYNCMARKS_TEST_REPO if present, then create it (private, auto_init).
+ * Requires PAT scope delete_repo for user-owned repos (classic PAT).
+ */
+async function ensureFreshTestRepository() {
+    step('Provisioning repository (--ensure-repo): delete if exists, then create...');
+
+    const meta = await githubCountedFetch(repoUrl(''));
+    if (meta?._status === 404) {
+        info('Repository does not exist yet.');
+    } else {
+        info(`Deleting existing ${getEnv().owner}/${getEnv().repo}...`);
+        await githubCountedFetch(repoUrl(''), { method: 'DELETE' });
+        ok('Repository deleted.');
+        await sleep(2500);
+    }
+
+    const { owner, repo } = getEnv();
+    const user = await githubCountedFetch(`${API_BASE}/user`);
+    const createUrl =
+        user.login.toLowerCase() === owner.toLowerCase()
+            ? `${API_BASE}/user/repos`
+            : `${API_BASE}/orgs/${encodeURIComponent(owner)}/repos`;
+
+    const createBody = JSON.stringify({
+        name: repo,
+        private: true,
+        description: 'Disposable test repo for GitSyncMarks onboarding-scale / E2E',
+        auto_init: true,
+    });
+
+    let lastErr;
+    for (let attempt = 0; attempt < 6; attempt++) {
+        try {
+            const created = await githubCountedFetch(createUrl, {
+                method: 'POST',
+                body: createBody,
+            });
+            ok(`Created repository: ${created.full_name || `${owner}/${repo}`}`);
+            return;
+        } catch (err) {
+            lastErr = err;
+            const msg = err.message || '';
+            const nameStillInUse =
+                msg.includes('422') &&
+                (msg.includes('already exists') || msg.includes('name already'));
+            if (nameStillInUse && attempt < 5) {
+                warn(`Create failed (name may still be reserved); waiting ${2 * (attempt + 1)}s before retry...`);
+                await sleep(2000 * (attempt + 1));
+                continue;
+            }
+            throw err;
+        }
+    }
+    throw lastErr;
+}
+
 // ---- Repo helpers ----
 function repoUrl(path = '') {
     const { owner, repo } = getEnv();
@@ -156,7 +246,6 @@ async function getRateLimit() {
 }
 
 async function getLatestCommitSha() {
-    const { repo: repoBranch } = getEnv();
     const data = await ghFetch(repoUrl(`/git/ref/heads/main`));
     if (data?._status === 404 || data?._status === 409) return null;
     return data.object.sha;
@@ -211,7 +300,10 @@ async function createRef(commitSha) {
     });
 }
 
-// ---- Reset repo to empty (delete all files via API) ----
+/** Canonical empty tree object in Git (no files). One commit wipes all paths; avoids huge POST /git/trees bodies (422 BadObjectState). */
+const EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+// ---- Reset repo to empty (single commit to empty tree) ----
 async function resetRepoToEmpty() {
     step('Resetting repo to empty state...');
 
@@ -222,23 +314,19 @@ async function resetRepoToEmpty() {
     }
 
     const commit = await getCommit(commitSha);
-    const treeData = await ghFetch(repoUrl(`/git/trees/${commit.treeSha}?recursive=1`));
-    const items = (treeData.tree || []).filter(e => e.type === 'blob');
-
-    if (items.length === 0) {
+    if (commit.treeSha === EMPTY_TREE_SHA) {
         info('Repo tree is already empty.');
         return;
     }
 
-    info(`Found ${items.length} file(s) to delete.`);
-
-    // Delete all blobs by creating a tree with sha=null for each
-    const deleteItems = items.map(e => ({ path: e.path, mode: '100644', type: 'blob', sha: null }));
-    const newTreeSha = await createTree(null, deleteItems);
-    const newCommitSha = await createCommit('Reset: empty repo for onboarding test', newTreeSha, commitSha);
+    const newCommitSha = await createCommit(
+        'Reset: empty repo for onboarding test',
+        EMPTY_TREE_SHA,
+        commitSha
+    );
     await updateRef(newCommitSha);
 
-    ok(`Repo reset to empty. All ${items.length} file(s) deleted.`);
+    ok('Repo reset to empty (empty-tree commit).');
 }
 
 // ---- Generate synthetic bookmarks (simulating a user's bookmarks) ----
@@ -271,9 +359,9 @@ function generateSyntheticBookmarks(count, basePath = 'bookmarks') {
     return files;
 }
 
-// ---- SEQUENTIAL blob creation (current behavior — the bug) ----
+// ---- SEQUENTIAL blob creation (legacy — reproduces #51-style pressure) ----
 async function atomicCommitSequential(fileChanges, commitSha, treeSha) {
-    step('Strategy A: SEQUENTIAL blob creation (current behavior)');
+    step('Strategy A: SEQUENTIAL blob creation (legacy)');
     info(`Creating ${Object.keys(fileChanges).length} blobs one by one...`);
 
     const t0 = Date.now();
@@ -286,7 +374,7 @@ async function atomicCommitSequential(fileChanges, commitSha, treeSha) {
 
     const newTreeSha = await createTree(treeSha, treeItems);
     const newCommitSha = await createCommit(
-        `[TEST-SEQUENTIAL] Onboarding push — ${new Date().toISOString()}`,
+        `[TEST-SEQUENTIAL] Onboarding push (legacy) — ${new Date().toISOString()}`,
         newTreeSha,
         commitSha
     );
@@ -301,30 +389,27 @@ async function atomicCommitSequential(fileChanges, commitSha, treeSha) {
     return { elapsed, commitSha: newCommitSha };
 }
 
-// ---- PARALLEL blob creation (proposed fix) ----
-async function atomicCommitParallel(fileChanges, commitSha, treeSha, concurrency = 5) {
-    step(`Strategy B: PARALLEL blob creation (proposed fix, concurrency=${concurrency})`);
-    info(`Creating ${Object.keys(fileChanges).length} blobs in batches of ${concurrency}...`);
+// ---- Layered tree + inline content (matches lib/github-api.js atomicCommit) ----
+async function atomicCommitLayeredTrees(fileChanges, commitSha, treeSha, chunkAtomicCommitTreeBatches) {
+    const n = Object.keys(fileChanges).length;
+    const uploads = [];
+    for (const [p, content] of Object.entries(fileChanges)) {
+        if (content !== null) uploads.push({ path: p, content });
+    }
+    const batches = chunkAtomicCommitTreeBatches([], uploads);
+    step(
+        `Strategy B: Layered trees (extension-style, ${batches.length}× POST /git/trees, inline content)`
+    );
+    info(`Uploading ${n} files via tree API (GitHub creates blobs server-side)...`);
 
     const t0 = Date.now();
-    const entries = Object.entries(fileChanges);
-    const treeItems = [];
-
-    for (let i = 0; i < entries.length; i += concurrency) {
-        const batch = entries.slice(i, i + concurrency);
-        const settled = await Promise.all(
-            batch.map(async ([path, content]) => {
-                const blobSha = await createBlob(content);
-                return { path, mode: '100644', type: 'blob', sha: blobSha };
-            })
-        );
-        treeItems.push(...settled);
+    let nextTreeSha = treeSha;
+    for (const batch of batches) {
+        nextTreeSha = await createTree(nextTreeSha, batch);
     }
-
-    const newTreeSha = await createTree(treeSha, treeItems);
     const newCommitSha = await createCommit(
-        `[TEST-PARALLEL] Onboarding push — ${new Date().toISOString()}`,
-        newTreeSha,
+        `[TEST-LAYERED-TREE] Onboarding push — ${new Date().toISOString()}`,
+        nextTreeSha,
         commitSha
     );
 
@@ -359,11 +444,19 @@ function printSummary(label, { callsBefore, callsAfter, rateBefore, rateAfter, e
 
 // ---- Main ----
 async function main() {
+    const { chunkAtomicCommitTreeBatches } = await import(
+        pathToFileURL(path.join(__dirname, '..', 'lib', 'github-tree-batch.js')).href
+    );
+
     console.log(`\n${c.bold}GitSyncMarks Onboarding Rate-Limit Test${c.reset}`);
     console.log(`Simulating onboarding with ${c.bold}${bookmarkCount}${c.reset} bookmarks\n`);
 
     const { owner, repo } = getEnv();
     info(`Repo: ${owner}/${repo}`);
+
+    if (ensureRepo) {
+        await ensureFreshTestRepository();
+    }
 
     // 1. Check initial rate limit
     step('Checking initial rate limit...');
@@ -392,6 +485,26 @@ async function main() {
     const fileCount = Object.keys(bookmarkFiles).length;
     ok(`Generated ${fileCount} files (${bookmarkCount} bookmarks + structure files)`);
 
+    const treeLayers = Math.max(1, Math.ceil(fileCount / 400));
+    const approxCallsLayered = treeLayers + 4; // tree POSTs + commit + ref + overhead
+    const approxCallsSequential = fileCount + 3;
+    if (strategy === 'both' && bookmarkCount > 1500) {
+        warn(
+            `Default mode runs sequential blobs then layered trees (~${approxCallsSequential + approxCallsLayered} API calls). ` +
+                `For large repos use --parallel-only (extension behavior) or --sequential-only.`
+        );
+    }
+    const needRemaining =
+        strategy === 'sequential' || strategy === 'both'
+            ? approxCallsSequential + (strategy === 'both' ? approxCallsLayered : 0)
+            : approxCallsLayered;
+    if (initialRate.remaining < needRemaining + 20) {
+        warn(
+            `Roughly ${needRemaining} calls may be needed; only ${initialRate.remaining} remaining. ` +
+                `Test may fail with rate limit or 403.`
+        );
+    }
+
     // 4. Get current repo state
     step('Getting current repo state...');
     let currentCommitSha = null;
@@ -406,57 +519,84 @@ async function main() {
         info(`Current commit: ${currentCommitSha.substring(0, 12)}`);
     }
 
-    // 5. Run SEQUENTIAL test (current behavior)
-    const callsBefore_seq = totalCalls;
-    const rateBefore_seq = rateLimitEnd ?? initialRate.remaining;
     let seqResult;
-    try {
-        seqResult = await atomicCommitSequential(bookmarkFiles, currentCommitSha, currentTreeSha);
-        const rateAfter_seq = rateLimitEnd;
-        printSummary('Sequential (current behavior)', {
-            callsBefore: callsBefore_seq,
-            callsAfter: totalCalls,
-            rateBefore: rateBefore_seq,
-            rateAfter: rateAfter_seq,
-            elapsed: seqResult.elapsed,
-            commitSha: seqResult.commitSha,
-        });
-        // Update state for next test
-        currentCommitSha = seqResult.commitSha;
-        const updatedCommit = await getCommit(currentCommitSha);
-        currentTreeSha = updatedCommit.treeSha;
-    } catch (err) {
-        fail(`Sequential test FAILED: ${err.message}`);
-    }
-
-    // 6. Run PARALLEL test (proposed fix) — push on top of what we just created
-    console.log(`\n${c.gray}(Generating a fresh set of modified bookmarks for parallel test...)${c.reset}`);
-    const modifiedFiles = generateSyntheticBookmarks(bookmarkCount, basePath);
-    // Slightly modify content so blobs are different (forces re-upload)
-    for (const key of Object.keys(modifiedFiles)) {
-        if (key.endsWith('.json') && !key.endsWith('_index.json') && !key.endsWith('_order.json')) {
-            const obj = JSON.parse(modifiedFiles[key]);
-            obj.title = obj.title + ' (v2)';
-            modifiedFiles[key] = JSON.stringify(obj, null, 2);
-        }
-    }
-
-    const callsBefore_par = totalCalls;
-    const rateBefore_par = rateLimitEnd ?? initialRate.remaining;
     let parResult;
-    try {
-        parResult = await atomicCommitParallel(modifiedFiles, currentCommitSha, currentTreeSha, 5);
-        const rateAfter_par = rateLimitEnd;
-        printSummary('Parallel (proposed fix, concurrency=5)', {
-            callsBefore: callsBefore_par,
-            callsAfter: totalCalls,
-            rateBefore: rateBefore_par,
-            rateAfter: rateAfter_par,
-            elapsed: parResult.elapsed,
-            commitSha: parResult.commitSha,
-        });
-    } catch (err) {
-        fail(`Parallel test FAILED: ${err.message}`);
+    let hadFailure = false;
+
+    const runSequential = async () => {
+        const callsBefore_seq = totalCalls;
+        const rateBefore_seq = rateLimitEnd ?? initialRate.remaining;
+        try {
+            seqResult = await atomicCommitSequential(bookmarkFiles, currentCommitSha, currentTreeSha);
+            printSummary('Sequential (legacy / pre-#51 style)', {
+                callsBefore: callsBefore_seq,
+                callsAfter: totalCalls,
+                rateBefore: rateBefore_seq,
+                rateAfter: rateLimitEnd,
+                elapsed: seqResult.elapsed,
+                commitSha: seqResult.commitSha,
+            });
+            currentCommitSha = seqResult.commitSha;
+            const updatedCommit = await getCommit(currentCommitSha);
+            currentTreeSha = updatedCommit.treeSha;
+        } catch (err) {
+            hadFailure = true;
+            fail(`Sequential test FAILED: ${err.message}`);
+        }
+    };
+
+    const runParallel = async (files, label) => {
+        const callsBefore_par = totalCalls;
+        const rateBefore_par = rateLimitEnd ?? initialRate.remaining;
+        try {
+            parResult = await atomicCommitLayeredTrees(
+                files,
+                currentCommitSha,
+                currentTreeSha,
+                chunkAtomicCommitTreeBatches
+            );
+            printSummary(label, {
+                callsBefore: callsBefore_par,
+                callsAfter: totalCalls,
+                rateBefore: rateBefore_par,
+                rateAfter: rateLimitEnd,
+                elapsed: parResult.elapsed,
+                commitSha: parResult.commitSha,
+            });
+            currentCommitSha = parResult.commitSha;
+            const updatedCommit = await getCommit(currentCommitSha);
+            currentTreeSha = updatedCommit.treeSha;
+        } catch (err) {
+            hadFailure = true;
+            fail(`Parallel test FAILED: ${err.message}`);
+        }
+    };
+
+    info(`Strategy: ${c.bold}${strategy}${c.reset}`);
+
+    // 5–6. Run selected strategy(ies)
+    if (strategy === 'sequential' || strategy === 'both') {
+        await runSequential();
+    }
+
+    if (strategy === 'both' && hadFailure) {
+        fail('Skipping parallel pass because sequential run failed.');
+        process.exit(1);
+    }
+
+    if (strategy === 'parallel') {
+        await runParallel(bookmarkFiles, 'Layered trees (extension-style)');
+    } else if (strategy === 'both') {
+        console.log(`\n${c.gray}(Generating modified bookmarks for second pass — parallel comparison...)${c.reset}`);
+        const modifiedFiles = generateSyntheticBookmarks(bookmarkCount, basePath);
+        for (const key of Object.keys(modifiedFiles)) {
+            if (key.endsWith('.json') && !key.endsWith('_index.json') && !key.endsWith('_order.json')) {
+                const obj = JSON.parse(modifiedFiles[key]);
+                obj.title = `${obj.title} (v2)`;
+                modifiedFiles[key] = JSON.stringify(obj, null, 2);
+            }
+        }
+        await runParallel(modifiedFiles, 'Layered trees (extension-style)');
     }
 
     // 7. Final summary
@@ -464,14 +604,16 @@ async function main() {
     console.log(`${c.bold}TOTAL API CALLS: ${totalCalls}${c.reset}`);
     console.log(`${c.bold}TOTAL RATE LIMIT CONSUMED: ${initialRate.remaining - rateLimitEnd}${c.reset}`);
 
-    if (seqResult && parResult) {
+    if (seqResult && parResult && strategy === 'both') {
         const speedup = (seqResult.elapsed / parResult.elapsed).toFixed(2);
         console.log(`\n${c.bold}Comparison:${c.reset}`);
         console.log(`  Sequential time: ${(seqResult.elapsed / 1000).toFixed(2)}s`);
-        console.log(`  Parallel time:   ${(parResult.elapsed / 1000).toFixed(2)}s`);
-        console.log(`  Speedup:         ${c.green}${speedup}×${c.reset} faster`);
+        console.log(`  Layered-tree time: ${(parResult.elapsed / 1000).toFixed(2)}s`);
+        console.log(`  Speedup:           ${c.green}${speedup}×${c.reset} faster`);
     }
     console.log(`${'═'.repeat(60)}\n`);
+
+    if (hadFailure) process.exit(1);
 }
 
 main().catch((err) => {

--- a/scripts/verify-test-repo.js
+++ b/scripts/verify-test-repo.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * List blob paths in the E2E / onboarding test repo (branch main) and verify GitSyncMarks layout.
+ *
+ * Requires: GITSYNCMARKS_TEST_PAT, GITSYNCMARKS_TEST_REPO_OWNER, GITSYNCMARKS_TEST_REPO
+ *
+ * Usage:
+ *   GITSYNCMARKS_TEST_PAT=… GITSYNCMARKS_TEST_REPO_OWNER=… GITSYNCMARKS_TEST_REPO=… \
+ *     node scripts/verify-test-repo.js [--verbose] [--base-path bookmarks] [--min-bookmarks N]
+ *
+ * Options:
+ *   --verbose          Print every blob path (sorted)
+ *   --base-path PATH   Bookmark root (default: bookmarks)
+ *   --min-bookmarks N  Require at least N *.json files under …/toolbar/ (excluding _order.json)
+ *
+ * Exit 0 if checks pass; 1 if env missing, branch missing, tree truncated, required files missing, or min count not met.
+ */
+
+'use strict';
+
+const API_BASE = 'https://api.github.com';
+
+function getEnv() {
+  const token = process.env.GITSYNCMARKS_TEST_PAT;
+  const owner = process.env.GITSYNCMARKS_TEST_REPO_OWNER;
+  const repo = process.env.GITSYNCMARKS_TEST_REPO;
+  if (!token || !owner || !repo) {
+    console.error(
+      'Missing env: GITSYNCMARKS_TEST_PAT, GITSYNCMARKS_TEST_REPO_OWNER, GITSYNCMARKS_TEST_REPO\n' +
+        'See e2e/README.md and .env.example'
+    );
+    process.exit(1);
+  }
+  return { token, owner, repo };
+}
+
+async function githubJson(owner, repo, path, token) {
+  const url = `${API_BASE}/repos/${owner}/${repo}${path}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (res.status === 404) {
+    return { _status: 404, _body: await res.json().catch(() => ({})) };
+  }
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(`GitHub API ${res.status}: ${body.message || res.statusText}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const verbose = args.includes('--verbose');
+  const baseIdx = args.indexOf('--base-path');
+  const basePath = baseIdx !== -1 && args[baseIdx + 1] ? args[baseIdx + 1].replace(/\/$/, '') : 'bookmarks';
+  const minIdx = args.indexOf('--min-bookmarks');
+  const minBookmarks =
+    minIdx !== -1 ? parseInt(args[minIdx + 1], 10) : NaN;
+  const requireMin = Number.isFinite(minBookmarks) && minBookmarks >= 0;
+
+  const { token, owner, repo } = getEnv();
+
+  const ref = await githubJson(owner, repo, '/git/ref/heads/main', token);
+  if (ref._status === 404 || ref._status === 409) {
+    console.error('Branch `main` not found (empty or uninitialized repo).');
+    process.exit(1);
+  }
+  const commitSha = ref.object.sha;
+
+  const commit = await githubJson(owner, repo, `/git/commits/${commitSha}`, token);
+  const treeSha = commit.tree.sha;
+
+  const tree = await githubJson(owner, repo, `/git/trees/${treeSha}?recursive=1`, token);
+  if (tree.truncated) {
+    console.error('Tree listing was truncated by GitHub; cannot verify full file set. Use a smaller repo or paginate.');
+    process.exit(1);
+  }
+
+  const blobs = (tree.tree || []).filter((e) => e.type === 'blob');
+  const paths = new Set(blobs.map((e) => e.path));
+
+  const required = [
+    `${basePath}/_index.json`,
+    `${basePath}/toolbar/_order.json`,
+    `${basePath}/other/_order.json`,
+  ];
+  const missing = required.filter((p) => !paths.has(p));
+
+  const toolbarPrefix = `${basePath}/toolbar/`;
+  const toolbarBookmarkJson = blobs.filter(
+    (e) =>
+      e.path.startsWith(toolbarPrefix) &&
+      e.path.endsWith('.json') &&
+      !e.path.endsWith('_order.json')
+  );
+
+  console.log(`Repository: ${owner}/${repo}`);
+  console.log(`Branch: main @ ${commitSha.slice(0, 7)}`);
+  console.log(`Blobs: ${blobs.length} (recursive tree)`);
+
+  if (verbose) {
+    console.log('\nPaths:');
+    for (const p of [...paths].sort()) {
+      console.log(`  ${p}`);
+    }
+    console.log('');
+  }
+
+  if (missing.length) {
+    console.error('Missing required GitSyncMarks files:');
+    for (const m of missing) console.error(`  - ${m}`);
+    process.exit(1);
+  }
+  console.log('✓ Required structure: _index.json, toolbar/_order.json, other/_order.json');
+
+  if (requireMin) {
+    if (toolbarBookmarkJson.length < minBookmarks) {
+      console.error(
+        `Expected at least ${minBookmarks} bookmark JSON under ${toolbarPrefix} (excl. _order); found ${toolbarBookmarkJson.length}.`
+      );
+      process.exit(1);
+    }
+    console.log(`✓ Toolbar bookmarks: ${toolbarBookmarkJson.length} (minimum ${minBookmarks})`);
+  } else {
+    console.log(`  Toolbar bookmark JSON files (excl. _order): ${toolbarBookmarkJson.length}`);
+  }
+
+  console.log('\nOK — all checks passed.');
+}
+
+main().catch((err) => {
+  console.error(err.message || String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Fixes #51** — Onboarding flow hit GitHub API secondary rate limits, making initial setup unusable for users with large bookmark collections (~5000+).
- `atomicCommit` now embeds file content inline in `POST /git/trees` entries (GitHub creates blobs server-side) instead of issuing one `POST /git/blobs` per file. Large change sets are split into layered tree batches (~400 entries / ~28 MiB each).
- A ~5000-file first push now needs ~13 tree calls + commit + ref instead of ~5000 blob calls — much faster and far less likely to hit secondary rate limits.

## Changes

| File | Change |
|------|--------|
| `lib/github-tree-batch.js` (new) | Chunking utility: max entries + byte budget per batch |
| `lib/github-api.js` | `atomicCommit` uses `buildLayeredTree` with inline `content` |
| `scripts/test-onboarding-rate-limit.js` | Diagnostic script: `--ensure-repo`, layered tree path |
| `scripts/verify-test-repo.js` (new) | Verify repo contents via GitHub API |
| `manifest.json`, `manifest.firefox.json`, `package.json` | Version bump 2.7.0 → 2.7.1 |
| `CHANGELOG.md`, `docs/RELEASE.md` | Release notes for v2.7.1 |
| `docs/ARCHITECTURE.md`, `docs/SYNC-LOGIC.md`, `e2e/README.md` | Updated documentation |

## Test plan

- [x] `npm run build` succeeds locally
- [ ] CI build and unit tests pass
- [ ] Manual test: onboard with ~5000 bookmarks using `npm run test:onboarding-scale`
- [ ] `npm run verify-test-repo` confirms all files present after sync