### PR TITLE
fix(security): CodeQL — pin release actions, harden E2E repo-reset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    # Third-party actions below are pinned to full commit SHAs (CodeQL: actions/unpinned-tag).
+    # Refresh: gh api repos/<org>/<repo>/commits/<tag> -q .sha
 
     steps:
       - name: Checkout code
@@ -37,7 +39,7 @@ jobs:
 
       - name: Extract changelog
         id: changelog
-        uses: ffurrer2/extract-release-notes@v3
+        uses: ffurrer2/extract-release-notes@273da39a24fb7db106a35526c8162815faffd31d # v3
         with:
           changelog_file: CHANGELOG.md
 
@@ -54,7 +56,7 @@ jobs:
         run: bash scripts/build.sh
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           name: "GitSyncMarks ${{ steps.version.outputs.VERSION }}"
           prerelease: ${{ steps.prerelease.outputs.prerelease }}
@@ -89,7 +91,7 @@ jobs:
 
       - name: Create Release Discussion
         if: success()
-        uses: abirismyname/create-discussion@v2.1.0
+        uses: abirismyname/create-discussion@c2b7c825241769dda523865ae444a879f6bbd0e0 # v2.1.0
         with:
           title: "${{ steps.version.outputs.VERSION }} — Released"
           body: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CodeQL / Code Scanning**: Pinned third-party actions in [`.github/workflows/release.yml`](.github/workflows/release.yml) to full commit SHAs (`actions/unpinned-tag`). Hardened [`e2e/helpers/repo-reset.js`](e2e/helpers/repo-reset.js) with `fs.mkdtempSync` for the clone directory, `execFileSync('git', …)` instead of shell `execSync`, and validation of test repo owner/name (`js/insecure-temporary-file`, `js/indirect-command-line-injection`).
+
 ## [2.7.1] - 2026-03-28 (*Spock*)
 
 ### Improved

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -96,6 +96,12 @@ Create a **Poll** in [Discussions → Polls](https://github.com/d0dg3r/GitSyncMa
 | 7 | Tag and push: `git tag v2.2.0 && git push origin v2.2.0` |
 | 8 | GitHub Actions creates the release with ZIPs |
 
+**Third-party Actions in `release.yml`:** Pin each non-`actions/*` `uses:` reference to a full commit SHA (not only a moving tag) so CodeQL’s `actions/unpinned-tag` stays satisfied. Resolve a tag to the current commit with:
+
+```bash
+gh api repos/<org>/<repo>/commits/<tag> -q .sha
+```
+
 ### 2.6.0 Preparation Checklist
 
 Use this sequence when preparing `2.6.0`:

--- a/e2e/helpers/repo-reset.js
+++ b/e2e/helpers/repo-reset.js
@@ -7,10 +7,13 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const os = require('os');
 
 const BASE_PATH = 'bookmarks';
+
+/** GitHub owner and repo name segments (no shell metacharacters). */
+const SAFE_REPO_SEGMENT = /^[a-zA-Z0-9._-]+$/;
 
 function createMinimalStructure(dir) {
   const bookmarksDir = path.join(dir, BASE_PATH);
@@ -30,9 +33,16 @@ function createMinimalStructure(dir) {
   }
 }
 
-function runGit(command, { cwd } = {}) {
+/**
+ * Run git without a shell (avoids CodeQL js/indirect-command-line-injection on env-derived strings).
+ * @param {string | undefined} cwd
+ * @param {string[]} args
+ * @param {string} [label]
+ * @returns {string}
+ */
+function gitExec(cwd, args, label = 'git') {
   try {
-    return execSync(command, {
+    return execFileSync('git', args, {
       cwd,
       stdio: 'pipe',
       encoding: 'utf-8',
@@ -41,7 +51,25 @@ function runGit(command, { cwd } = {}) {
     const stdout = String(err?.stdout || '').trim();
     const stderr = String(err?.stderr || '').trim();
     const detail = [stdout, stderr].filter(Boolean).join('\n');
-    throw new Error(`repo-reset git command failed: ${command}${detail ? `\n${detail}` : ''}`);
+    throw new Error(
+      `repo-reset git failed (${label}): ${args.join(' ')}${detail ? `\n${detail}` : ''}`
+    );
+  }
+}
+
+/**
+ * @param {string} cloneDir
+ * @returns {boolean}
+ */
+function hasStagedChanges(cloneDir) {
+  try {
+    execFileSync('git', ['diff', '--cached', '--quiet'], {
+      cwd: cloneDir,
+      stdio: 'pipe',
+    });
+    return false;
+  } catch {
+    return true;
   }
 }
 
@@ -60,11 +88,17 @@ async function resetTestRepo() {
     );
   }
 
-  const cloneDir = path.join(os.tmpdir(), `gitsyncmarks-reset-${Date.now()}`);
+  if (!SAFE_REPO_SEGMENT.test(owner) || !SAFE_REPO_SEGMENT.test(repo)) {
+    throw new Error(
+      'Invalid GITSYNCMARKS_TEST_REPO_OWNER or GITSYNCMARKS_TEST_REPO (use [a-zA-Z0-9._-]+ only)'
+    );
+  }
+
+  const cloneDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitsyncmarks-reset-'));
   const url = `https://${token}@github.com/${owner}/${repo}.git`;
 
   try {
-    runGit(`git clone --depth 1 ${url} ${cloneDir}`);
+    gitExec(undefined, ['clone', '--depth', '1', url, cloneDir], 'clone');
 
     // Remove existing bookmarks, create minimal structure
     const bookmarksPath = path.join(cloneDir, BASE_PATH);
@@ -73,19 +107,11 @@ async function resetTestRepo() {
     }
     createMinimalStructure(cloneDir);
 
-    runGit('git add -A', { cwd: cloneDir });
-    const hasChanges = (() => {
-      try {
-        execSync('git diff --cached --quiet', { cwd: cloneDir, stdio: 'pipe' });
-        return false;
-      } catch {
-        return true;
-      }
-    })();
+    gitExec(cloneDir, ['add', '-A'], 'add');
 
-    if (hasChanges) {
-      runGit('git commit -m "E2E reset: minimal bookmark structure"', { cwd: cloneDir });
-      runGit('git push --force origin main', { cwd: cloneDir });
+    if (hasStagedChanges(cloneDir)) {
+      gitExec(cloneDir, ['commit', '-m', 'E2E reset: minimal bookmark structure'], 'commit');
+      gitExec(cloneDir, ['push', '--force', 'origin', 'main'], 'push');
     }
 
     fs.rmSync(cloneDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
Resolves open Code Scanning (CodeQL) findings:

- **`actions/unpinned-tag`**: Pin `ffurrer2/extract-release-notes`, `softprops/action-gh-release`, and `abirismyname/create-discussion` to full commit SHAs in `.github/workflows/release.yml`.
- **`js/insecure-temporary-file` / `js/indirect-command-line-injection`**: `e2e/helpers/repo-reset.js` now uses `fs.mkdtempSync`, `execFileSync('git', …)` (no shell), and validates `GITSYNCMARKS_TEST_REPO_OWNER` / `GITSYNCMARKS_TEST_REPO` with a safe segment pattern.

## Docs
- `CHANGELOG.md` ([Unreleased])
- `docs/RELEASE.md` — how to resolve action tag → SHA with `gh api`

## Verification
- `npm run test:unit` passes locally.

After merge, confirm CodeQL re-runs and `gh api repos/d0dg3r/GitSyncMarks/code-scanning/alerts` shows no remaining open alerts for these rules.