### PR TITLE
fix(sync): clear lastError on successful no-change sync paths

### DIFF
--- a/lib/sync-core.js
+++ b/lib/sync-core.js
@@ -616,7 +616,7 @@ export async function sync() {
 
     // 6. No changes on either side
     if (!localHasChanges && !remoteHasChanges) {
-      await setSyncState(profileId, { lastSyncTime: new Date().toISOString() });
+      await setSyncState(profileId, { lastSyncTime: new Date().toISOString(), lastError: null });
       return { success: true, message: getMessage('sync_allInSync') };
     }
 
@@ -650,7 +650,7 @@ export async function sync() {
       const verifySha = await api.getLatestCommitSha();
       if (verifySha !== remote.commitSha) {
         await debugLog(`sync() path8 guard: remote.commitSha=${remote.commitSha?.substring(0, 7)} != verifySha=${verifySha?.substring(0, 7)} — skipping pull (stale fetch)`);
-        await setSyncState(profileId, { lastSyncTime: new Date().toISOString() });
+        await setSyncState(profileId, { lastSyncTime: new Date().toISOString(), lastError: null });
         return { success: true, message: getMessage('sync_allInSync') };
       }
       // Save previous commit SHA for undo


### PR DESCRIPTION
## Description
This fix sets sync state "lastError" field to null on successful sync() execution paths.

## Related Issue
Fixes #128 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🧹 Refactoring / Code quality
- [ ] 📝 Documentation update
- [ ] 🌐 Translation (i18n)

## Checklist
- [x] I have followed the existing code style.
- [x] I have tested my changes in **Google Chrome** (build/chrome).
- [ ] I have tested my changes in **Mozilla Firefox** (build/firefox).
- [x] I have updated the documentation / README if necessary.
- [x] My changes generate no new linting warnings or errors.
