### PR TITLE
Fix onboarding wizard stuck on empty auto-created repos (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Onboarding wizard empty-repo flow** ([#173](https://github.com/d0dg3r/GitSyncMarks/issues/173)): Auto-created repositories with no commits no longer get stuck on step 7/8. The wizard now treats zero-commit repositories as empty, auto-creates the initial bookmark folder structure for greenfield auto-create setups, and recognizes structure-only remotes as ready (`structureReady`). Connection/path validation now blocks file-like base paths such as `bookmarks.json` and requires a folder path (for example `bookmarks`).
+
 ## [3.0.3] - 2026-06-17
 
 ### Added

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -516,10 +516,19 @@
     "message": "Branch"
   },
   "options_filePath": {
-    "message": "File Path in Repository"
+    "message": "Folder Path in Repository"
   },
   "options_filePathHint": {
-    "message": "Folder where bookmark files will be stored."
+    "message": "Folder where bookmark files are stored (for example: bookmarks). Do not use a .json filename."
+  },
+  "options_filePathInvalidEmpty": {
+    "message": "Folder path is empty. Enter a folder name like \"bookmarks\"."
+  },
+  "options_filePathInvalidAbsolute": {
+    "message": "Folder path must be relative to the repository root (for example: bookmarks)."
+  },
+  "options_filePathInvalidJsonFile": {
+    "message": "Folder path must be a folder (for example: bookmarks), not a .json file name."
   },
   "options_browseFolder": {
     "message": "Browse"
@@ -1001,6 +1010,9 @@
   "options_onboardingWizardSyncWarn_emptyBoth": {
     "message": "Remote path and browser are empty. Create the folder structure or skip and sync later."
   },
+  "options_onboardingWizardSyncWarn_structureReady": {
+    "message": "Folder structure already exists and there are no bookmarks yet. You can continue and sync later."
+  },
   "options_onboardingWizardSyncWarn_pushDanger": {
     "message": "Warning: push will delete $1 remote bookmark file(s) not present locally and replace the repository with this browser's bookmarks."
   },
@@ -1153,6 +1165,9 @@
   },
   "options_onboardingWizardEnvironmentChecked": {
     "message": "Repository and path check completed."
+  },
+  "options_onboardingWizardAutoSeedSuccess": {
+    "message": "Created initial folder structure at \"$1\". Setup can continue."
   },
   "options_onboardingWizardSyncInProgress": {
     "message": "Working in background, please wait..."
@@ -1646,7 +1661,7 @@
     "message": "Getting Started"
   },
   "help_gettingStartedIntro": {
-    "message": "Create a Git repository for your bookmarks on <strong>GitHub</strong>, <strong>GitLab</strong>, <strong>Codeberg</strong>, <strong>Gitea</strong>, <strong>Forgejo</strong>, or <strong>Gogs</strong>. In <strong>Git → Connection</strong>, choose your provider, enter a Personal Access Token, repository owner/name, branch (usually <code>main</code>), and folder path (default: <code>bookmarks</code>). Self-hosted providers need a server URL; allow host access when prompted. Click <strong>Test Connection</strong> to verify."
+    "message": "Create a Git repository for your bookmarks on <strong>GitHub</strong>, <strong>GitLab</strong>, <strong>Codeberg</strong>, <strong>Gitea</strong>, <strong>Forgejo</strong>, or <strong>Gogs</strong>. In <strong>Git → Connection</strong>, choose your provider, enter a Personal Access Token, repository owner/name, branch (usually <code>main</code>), and folder path (default: <code>bookmarks</code>, not a <code>.json</code> filename). Self-hosted providers need a server URL; allow host access when prompted. Click <strong>Test Connection</strong> to verify."
   },
   "help_onboarding": {
     "message": "If the folder is empty, you can create the base structure (toolbar, other). If bookmarks already exist in the repo, you can pull them into this browser."

--- a/e2e/connection.spec.js
+++ b/e2e/connection.spec.js
@@ -69,6 +69,27 @@ async function seedLocalBookmarksForToolbarAndOther(page, suffix) {
   }, { suffixArg: suffix });
 }
 
+async function clearLocalBookmarks(page) {
+  await page.evaluate(async () => {
+    const roots = await chrome.bookmarks.getChildren('0');
+    for (const root of roots) {
+      if (!root?.id) continue;
+      const children = await chrome.bookmarks.getChildren(root.id);
+      for (const node of children) {
+        try {
+          if (node.children) {
+            await chrome.bookmarks.removeTree(node.id);
+          } else {
+            await chrome.bookmarks.remove(node.id);
+          }
+        } catch {
+          // Ignore managed or undeletable nodes in test profile.
+        }
+      }
+    }
+  });
+}
+
 async function openWizardAndAdvanceToRepoDetails(page) {
   const wizard = page.locator('#onboarding-wizard-screen');
   if (!(await wizard.isVisible())) {
@@ -187,6 +208,23 @@ test.describe('Connection', () => {
     await test.expect(page.locator('#onboarding-wizard-step-title')).toContainText(/Repository setup mode/i);
   });
 
+  test.skip(!hasTokenOnly(), 'Missing token for path validation test');
+  test('Wizard blocks file-like base path values', async ({ page, extensionId }) => {
+    await openOptions(page, extensionId);
+    await openWizardAndAdvanceToRepoDetails(page);
+
+    await page.locator('#onboarding-wizard-repo-flow').selectOption('manual');
+    await page.locator('#onboarding-wizard-next-btn').click(); // repoDecision -> repoDetails
+    await page.locator('#onboarding-wizard-owner').fill('owner');
+    await page.locator('#onboarding-wizard-repo').fill('repo');
+    await page.locator('#onboarding-wizard-path').fill('bookmarks.json');
+
+    await page.locator('#onboarding-wizard-next-btn').click();
+
+    await test.expect(page.locator('#onboarding-wizard-step-title')).toContainText(/Repository details|Repository setup/i);
+    await test.expect(page.locator('#onboarding-wizard-hint')).toContainText(/folder path must be a folder/i);
+  });
+
   test.describe('Invalid token', () => {
     test('Test Connection fails with invalid token', async ({ page, extensionId }) => {
       await page.goto(`chrome-extension://${extensionId}/options.html`);
@@ -208,6 +246,43 @@ test.describe('Connection', () => {
 
   test.describe('Valid credentials', () => {
     test.skip(!hasTokenAndOwner(), 'Missing token/owner for onboarding bootstrap auto-create test');
+    test('Bootstrap scenario A0: auto-created empty repo auto-seeds structure', async ({ page, extensionId }, testInfo) => {
+      test.setTimeout(90000);
+      const token = process.env.GITSYNCMARKS_TEST_PAT;
+      const owner = process.env.GITSYNCMARKS_TEST_REPO_OWNER;
+      const createdRepo = `gitsyncmarks-e2e-autoseed-${Date.now()}`;
+      const basePath = 'bookmarks';
+      await openOptions(page, extensionId);
+      await disableAutoSync(page);
+      await clearLocalBookmarks(page);
+
+      try {
+        await openWizardAndAdvanceToRepoDetails(page);
+        await page.locator('#onboarding-wizard-repo-flow').selectOption('autoCreate');
+        await page.locator('#onboarding-wizard-next-btn').click(); // repoDecision -> repoDetails
+        await page.locator('#onboarding-wizard-repo').fill(createdRepo);
+        await page.locator('#onboarding-wizard-branch').fill('main');
+        await page.locator('#onboarding-wizard-path').fill(basePath);
+        await page.locator('#onboarding-wizard-next-btn').click(); // repoDetails -> environment
+        await page.locator('#onboarding-wizard-next-btn').click(); // environment -> auto-seed check
+        await page.locator('#onboarding-wizard-next-btn').click(); // environment -> finish
+        await test.expect(page.locator('#onboarding-wizard-step-title')).toContainText(/all set|fertig|ready|finish/i, { timeout: 60000 });
+
+        const repoTarget = { owner, repo: createdRepo };
+        await githubFetch(`/contents/${basePath}/_index.json`, {}, repoTarget);
+      } finally {
+        const cleanupResult = await deleteE2eRepoIfSafe({ token, owner, repo: createdRepo });
+        await testInfo.attach('autoseed-repo-cleanup', {
+          contentType: 'application/json',
+          body: Buffer.from(JSON.stringify({
+            owner,
+            repo: createdRepo,
+            ...cleanupResult,
+          }, null, 2)),
+        });
+      }
+    });
+
     test('Bootstrap scenario A: auto-created repo syncs toolbar + other bookmarks', async ({ page, extensionId }, testInfo) => {
       test.setTimeout(90000);
       const token = process.env.GITSYNCMARKS_TEST_PAT;

--- a/lib/onboarding.js
+++ b/lib/onboarding.js
@@ -6,6 +6,7 @@
 
 import { GitHubError } from './github-api.js';
 import { fetchRemoteFileMap } from './remote-fetch.js';
+import { hasBookmarkPayloadFiles } from './sync-settings.js';
 
 const REMOTE_BASELINE_RETRIES = 10;
 const REMOTE_BASELINE_DELAY_MS = 500;
@@ -46,28 +47,31 @@ export async function waitForRemoteBaseline(api) {
  * Check if the bookmark path exists and whether it has bookmarks.
  * @param {import('./github-api.js').GitHubAPI} api
  * @param {string} basePath
- * @returns {Promise<{status: 'unreachable'|'empty'|'hasBookmarks', fileMap?: object, commitSha?: string}>}
+ * @param {{ fetchRemoteFileMapFn?: typeof fetchRemoteFileMap }} [deps]
+ * @returns {Promise<{status: 'unreachable'|'empty'|'structureReady'|'hasBookmarks', fileMap?: object, commitSha?: string}>}
  */
-export async function checkPathSetup(api, basePath) {
+export async function checkPathSetup(api, basePath, deps = {}) {
   const normalizedPath = (basePath || 'bookmarks').replace(/\/+$/, '');
+  const fetchRemoteFileMapFn = deps.fetchRemoteFileMapFn || fetchRemoteFileMap;
   try {
-    const remote = await fetchRemoteFileMap(api, normalizedPath, null);
+    const remote = await fetchRemoteFileMapFn(api, normalizedPath, null);
     if (!remote) {
-      return { status: 'unreachable' };
+      return { status: 'empty' };
     }
     const { fileMap, commitSha } = remote;
     const paths = Object.keys(fileMap || {});
     if (paths.length === 0) {
       return { status: 'empty' };
     }
-    const hasBookmarkFiles = paths.some(
+    const hasBookmarkFiles = hasBookmarkPayloadFiles(fileMap);
+    const hasStructureFiles = paths.some(
       (p) =>
-        !p.endsWith('_order.json') &&
-        !p.endsWith('_index.json') &&
-        p.endsWith('.json')
+        p === `${normalizedPath}/_index.json` ||
+        p === `${normalizedPath}/toolbar/_order.json` ||
+        p === `${normalizedPath}/other/_order.json`
     );
     return {
-      status: hasBookmarkFiles ? 'hasBookmarks' : 'empty',
+      status: hasBookmarkFiles ? 'hasBookmarks' : (hasStructureFiles ? 'structureReady' : 'empty'),
       fileMap,
       commitSha,
     };
@@ -77,6 +81,25 @@ export async function checkPathSetup(api, basePath) {
     }
     throw err;
   }
+}
+
+/**
+ * Validate and normalize the repository base path used for bookmark files.
+ * @param {string|null|undefined} basePath
+ * @returns {{ valid: boolean, normalizedPath: string, errorKey?: string }}
+ */
+export function validateSyncBasePath(basePath) {
+  const normalizedPath = (basePath || 'bookmarks').trim().replace(/\/+$/, '');
+  if (!normalizedPath) {
+    return { valid: false, normalizedPath: '', errorKey: 'options_filePathInvalidEmpty' };
+  }
+  if (normalizedPath.startsWith('/')) {
+    return { valid: false, normalizedPath, errorKey: 'options_filePathInvalidAbsolute' };
+  }
+  if (normalizedPath.endsWith('.json')) {
+    return { valid: false, normalizedPath, errorKey: 'options_filePathInvalidJsonFile' };
+  }
+  return { valid: true, normalizedPath };
 }
 
 /**

--- a/lib/wizard-sync-choice.js
+++ b/lib/wizard-sync-choice.js
@@ -72,6 +72,21 @@ export function buildWizardSyncOptions(pathStatus, localCount, remoteCount) {
     };
   }
 
+  if (pathStatus === 'structureReady') {
+    if (localHas) {
+      return {
+        modes: ['push', 'skip'],
+        defaultMode: 'push',
+        warningKey: 'options_onboardingWizardSyncWarn_localOnly',
+      };
+    }
+    return {
+      modes: ['skip'],
+      defaultMode: 'skip',
+      warningKey: 'options_onboardingWizardSyncWarn_structureReady',
+    };
+  }
+
   if (localHas) {
     return {
       modes: ['push', 'skip'],

--- a/options.html
+++ b/options.html
@@ -116,7 +116,7 @@
         <input type="text" id="onboarding-wizard-repo" placeholder="my-bookmarks">
         <label for="onboarding-wizard-branch" data-i18n="options_branch">Branch</label>
         <input type="text" id="onboarding-wizard-branch" placeholder="main" value="main">
-        <label for="onboarding-wizard-path" data-i18n="options_filePath">File Path in Repository</label>
+        <label for="onboarding-wizard-path" data-i18n="options_filePath">Folder Path in Repository</label>
         <input type="text" id="onboarding-wizard-path" placeholder="bookmarks" value="bookmarks">
       </div>
 
@@ -345,7 +345,7 @@
             </div>
 
             <div class="form-group">
-              <label for="filepath" data-i18n="options_filePath">File Path in Repository</label>
+              <label for="filepath" data-i18n="options_filePath">Folder Path in Repository</label>
               <div class="filepath-browse-wrapper">
                 <input type="text" id="filepath" placeholder="bookmarks" value="bookmarks">
                 <button type="button" id="btn-browse-folder" class="btn-icon" data-i18n-title="options_browseFolder"
@@ -369,7 +369,7 @@
                 <div id="folder-browser-loading" class="folder-browser-msg" data-i18n="options_browseFolderLoading">
                   Loading…</div>
               </div>
-              <small data-i18n="options_filePathHint">Folder where bookmark files will be stored.</small>
+              <small data-i18n="options_filePathHint">Folder where bookmark files are stored (for example: bookmarks). Do not use a .json filename.</small>
             </div>
 
             <section class="card card-nested" id="mirrors-card">

--- a/options/wizard.js
+++ b/options/wizard.js
@@ -12,7 +12,12 @@ import {
   providerNeedsHostPermission,
   renderProviderOptions,
 } from '../lib/provider-ui.js';
-import { checkPathSetup, initializeRemoteFolder, waitForRemoteBaseline } from '../lib/onboarding.js';
+import {
+  checkPathSetup,
+  initializeRemoteFolder,
+  validateSyncBasePath,
+  waitForRemoteBaseline,
+} from '../lib/onboarding.js';
 import { formatSyncProgress, runSyncPortAction } from '../lib/sync-progress.js';
 import {
   buildWizardSyncOptions,
@@ -351,7 +356,7 @@ export function renderOnboardingWizardStep() {
 
 function populateWizardSyncModeSelect() {
   if (!onboardingWizardSyncModeSelect) return;
-  const { modes, defaultMode, warningKey } = buildWizardSyncOptions(
+  const { modes, defaultMode } = buildWizardSyncOptions(
     wizardState.pathStatus,
     wizardState.localBookmarkCount,
     wizardState.remoteBookmarkCount
@@ -429,7 +434,12 @@ async function executeWizardSyncAction(mode) {
   syncWizardFieldsToConnectionForm();
   await _saveSettings();
   const fields = getWizardConnectionFields();
-  const basePath = onboardingWizardPathInput.value.trim() || 'bookmarks';
+  const basePathValidation = validateSyncBasePath(onboardingWizardPathInput.value);
+  if (!basePathValidation.valid) {
+    setWizardResult(getMessage(basePathValidation.errorKey || 'options_filePathInvalidEmpty'), 'error');
+    return false;
+  }
+  const basePath = basePathValidation.normalizedPath;
   const api = createConnectionApi(fields);
   const connection = getConnectionFormFieldsFromPage();
   const onProgress = (payload) => {
@@ -552,7 +562,6 @@ async function initializePathAndRunFirstPush(onProgress) {
 }
 
 async function validateAndInspectRepo({ offerInteractiveActions = true } = {}) {
-  await _saveSettings();
   const fields = getConnectionFormFieldsFromPage();
 
   if (!fields.token) {
@@ -566,6 +575,15 @@ async function validateAndInspectRepo({ offerInteractiveActions = true } = {}) {
   if (!(await ensureWizardHostPermission(fields))) {
     return { ok: false };
   }
+  const basePathValidation = validateSyncBasePath(filepathInput.value);
+  if (!basePathValidation.valid) {
+    hideConnectionPathInitAction();
+    showValidation(getMessage(basePathValidation.errorKey || 'options_filePathInvalidEmpty'), 'error');
+    return { ok: false };
+  }
+  const basePath = basePathValidation.normalizedPath;
+  filepathInput.value = basePath;
+  await _saveSettings();
 
   showValidation(getMessage('options_checking'), 'loading');
 
@@ -595,7 +613,6 @@ async function validateAndInspectRepo({ offerInteractiveActions = true } = {}) {
         showValidation(getMessage('options_tokenValidRepoNotFound', [tokenResult.username, `${fields.owner}/${fields.repo}`]), 'error');
         return { ok: false };
       }
-      const basePath = filepathInput.value.trim() || 'bookmarks';
       const pathCheck = await checkPathSetup(api, basePath);
       if (offerInteractiveActions && (pathCheck.status === 'unreachable' || pathCheck.status === 'empty')) {
         showConnectionPathInitAction(basePath);
@@ -726,11 +743,17 @@ async function runWizardEnvironmentCheck() {
     return false;
   }
 
+  const basePathValidation = validateSyncBasePath(onboardingWizardPathInput.value);
+  if (!basePathValidation.valid) {
+    setWizardResult(getMessage(basePathValidation.errorKey || 'options_filePathInvalidEmpty'), 'error');
+    return false;
+  }
+  onboardingWizardPathInput.value = basePathValidation.normalizedPath;
   syncWizardFieldsToConnectionForm();
   await _saveSettings();
 
   const fields = getWizardConnectionFields();
-  const basePath = onboardingWizardPathInput.value.trim() || 'bookmarks';
+  const basePath = basePathValidation.normalizedPath;
   if (!fields.owner || !fields.repo) {
     setWizardResult(getMessage('options_onboardingWizardRepoRequired'), 'error');
     return false;
@@ -787,13 +810,51 @@ async function runWizardEnvironmentCheck() {
     stopPathPulse();
   }
 
+  const localBookmarkCount = await countLocalBookmarks();
+  let remoteBookmarkCount = countRemoteBookmarks(pathCheck.fileMap);
+  let pathStatus = pathCheck.status;
+  let firstSyncDone = false;
+
+  const shouldAutoSeedStructure = (
+    onboardingWizardRepoFlowSelect.value === 'autoCreate' &&
+    (pathStatus === 'empty' || pathStatus === 'unreachable') &&
+    localBookmarkCount === 0 &&
+    remoteBookmarkCount === 0
+  );
+
+  if (shouldAutoSeedStructure) {
+    const stopAutoSeedPulse = startProgressPulse([
+      'Preparing repository baseline',
+      'Creating initial folder structure',
+    ], 2500);
+    try {
+      await waitForRemoteBaseline(api);
+      await initializeRemoteFolder(api, basePath);
+      pathCheck = await checkPathSetup(api, basePath);
+      pathStatus = pathCheck.status;
+      remoteBookmarkCount = countRemoteBookmarks(pathCheck.fileMap);
+      firstSyncDone = true;
+    } finally {
+      stopAutoSeedPulse();
+    }
+  }
+
+  if (!firstSyncDone && pathStatus === 'structureReady' && localBookmarkCount === 0) {
+    firstSyncDone = true;
+  }
+
   wizardState.repoRef = `${fields.owner}/${fields.repo}`;
-  wizardState.pathStatus = pathCheck.status;
-  wizardState.remoteBookmarkCount = countRemoteBookmarks(pathCheck.fileMap);
-  wizardState.localBookmarkCount = await countLocalBookmarks();
-  wizardState.firstSyncDone = false;
+  wizardState.pathStatus = pathStatus;
+  wizardState.remoteBookmarkCount = remoteBookmarkCount;
+  wizardState.localBookmarkCount = localBookmarkCount;
+  wizardState.firstSyncDone = firstSyncDone;
   wizardState.environmentChecked = true;
-  setWizardResult(getMessage('options_onboardingWizardEnvironmentChecked'), 'success');
+  setWizardResult(
+    firstSyncDone
+      ? getMessage('options_onboardingWizardAutoSeedSuccess', [basePath])
+      : getMessage('options_onboardingWizardEnvironmentChecked'),
+    'success'
+  );
   renderOnboardingWizardStep();
   return true;
 }
@@ -870,7 +931,14 @@ export function initWizard({ saveSettings }) {
 
   connectionPathInitBtn.addEventListener('click', async () => {
     const fields = getConnectionFormFieldsFromPage();
-    const basePath = connectionPathInitGroup.dataset.path || filepathInput.value.trim() || 'bookmarks';
+    const basePathValidation = validateSyncBasePath(
+      connectionPathInitGroup.dataset.path || filepathInput.value
+    );
+    if (!basePathValidation.valid) {
+      showValidation(getMessage(basePathValidation.errorKey || 'options_filePathInvalidEmpty'), 'error');
+      return;
+    }
+    const basePath = basePathValidation.normalizedPath;
     if (!fields.token || !fields.owner || !fields.repo) {
       showValidation(getMessage('options_browseFolderNotConfigured'), 'error');
       return;
@@ -892,7 +960,12 @@ export function initWizard({ saveSettings }) {
       }
       showValidation(getMessage('popup_syncing'), 'loading');
       if (gate.mode === 'initialize') {
+        await waitForRemoteBaseline(api);
         await initializeRemoteFolder(api, basePath);
+      } else if (gate.mode === 'skip') {
+        hideConnectionPathInitAction();
+        showValidation(getMessage('options_onboardingWizardAutoSeedSuccess', [basePath]), 'success');
+        return;
       } else if (gate.mode === 'push') {
         await assertSafeWizardPush(api, basePath);
         const pushResult = await runSyncPortAction('push', {}, (payload) => {
@@ -1023,6 +1096,14 @@ export function initWizard({ saveSettings }) {
       }
       if (stepKey === 'repoDecision') {
         wizardState.repoFlow = onboardingWizardRepoFlowSelect.value;
+      }
+      if (stepKey === 'repoDetails') {
+        const basePathValidation = validateSyncBasePath(onboardingWizardPathInput.value);
+        if (!basePathValidation.valid) {
+          setWizardResult(getMessage(basePathValidation.errorKey || 'options_filePathInvalidEmpty'), 'error');
+          return;
+        }
+        onboardingWizardPathInput.value = basePathValidation.normalizedPath;
       }
       if (stepKey === 'environment') {
         if (!wizardState.environmentChecked) {

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -1,0 +1,67 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { checkPathSetup, validateSyncBasePath } from '../lib/onboarding.js';
+
+describe('checkPathSetup', () => {
+  it('maps null remote map to empty status', async () => {
+    const result = await checkPathSetup({}, 'bookmarks', {
+      fetchRemoteFileMapFn: async () => null,
+    });
+    assert.equal(result.status, 'empty');
+  });
+
+  it('returns structureReady when only minimal structure exists', async () => {
+    const result = await checkPathSetup({}, 'bookmarks', {
+      fetchRemoteFileMapFn: async () => ({
+        commitSha: 'abc123',
+        fileMap: {
+          'bookmarks/_index.json': '{ "version": 2 }',
+          'bookmarks/toolbar/_order.json': '[]',
+          'bookmarks/other/_order.json': '[]',
+        },
+      }),
+    });
+    assert.equal(result.status, 'structureReady');
+  });
+
+  it('returns hasBookmarks when payload files exist', async () => {
+    const result = await checkPathSetup({}, 'bookmarks', {
+      fetchRemoteFileMapFn: async () => ({
+        commitSha: 'abc123',
+        fileMap: {
+          'bookmarks/_index.json': '{ "version": 2 }',
+          'bookmarks/toolbar/_order.json': '["example"]',
+          'bookmarks/toolbar/example_1abc.json': '{"id":"x","title":"Example","url":"https://example.com"}',
+        },
+      }),
+    });
+    assert.equal(result.status, 'hasBookmarks');
+  });
+});
+
+describe('validateSyncBasePath', () => {
+  it('accepts folder paths', () => {
+    const result = validateSyncBasePath('bookmarks/');
+    assert.equal(result.valid, true);
+    assert.equal(result.normalizedPath, 'bookmarks');
+  });
+
+  it('rejects empty paths', () => {
+    const result = validateSyncBasePath('   ');
+    assert.equal(result.valid, false);
+    assert.equal(result.errorKey, 'options_filePathInvalidEmpty');
+  });
+
+  it('rejects absolute paths', () => {
+    const result = validateSyncBasePath('/bookmarks');
+    assert.equal(result.valid, false);
+    assert.equal(result.errorKey, 'options_filePathInvalidAbsolute');
+  });
+
+  it('rejects file-like .json paths', () => {
+    const result = validateSyncBasePath('bookmarks.json');
+    assert.equal(result.valid, false);
+    assert.equal(result.errorKey, 'options_filePathInvalidJsonFile');
+  });
+});

--- a/test/wizard-sync-choice.test.js
+++ b/test/wizard-sync-choice.test.js
@@ -33,6 +33,18 @@ describe('buildWizardSyncOptions', () => {
     assert.equal(opts.defaultMode, 'initialize');
     assert.deepEqual(opts.modes, ['initialize', 'skip']);
   });
+
+  it('defaults to skip when structure exists and local is empty', () => {
+    const opts = buildWizardSyncOptions('structureReady', 0, 0);
+    assert.equal(opts.defaultMode, 'skip');
+    assert.deepEqual(opts.modes, ['skip']);
+  });
+
+  it('offers push when structure exists and local has bookmarks', () => {
+    const opts = buildWizardSyncOptions('structureReady', 2, 0);
+    assert.equal(opts.defaultMode, 'push');
+    assert.deepEqual(opts.modes, ['push', 'skip']);
+  });
 });
 
 describe('remoteHasBookmarkPayload', () => {


### PR DESCRIPTION
## Summary
- Treat zero-commit repositories as empty instead of unreachable during onboarding path checks.
- Add `structureReady` status when only minimal bookmark structure exists remotely.
- Validate folder base paths and reject file-like values such as `bookmarks.json`.
- Auto-seed initial folder structure in greenfield auto-create wizard flow.
- Wait for remote baseline before connection-tab structure initialization.

Fixes #173

## Test plan
- [x] `npm run test:unit`
- [x] `npx eslint` on touched JS files
- [ ] `npm run test:e2e:sync` (connection onboarding scenarios)