### PR TITLE
Release 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.4] - 2026-06-24
+
 ### Fixed
 - **Onboarding wizard empty-repo flow** ([#173](https://github.com/d0dg3r/GitSyncMarks/issues/173)): Auto-created repositories with no commits no longer get stuck on step 7/8. The wizard now treats zero-commit repositories as empty, auto-creates the initial bookmark folder structure for greenfield auto-create setups, and recognizes structure-only remotes as ready (`structureReady`). Connection/path validation now blocks file-like base paths such as `bookmarks.json` and requires a folder path (for example `bookmarks`).
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -41,6 +41,7 @@ The version is declared in `manifest.json` → `"version"`. It must match `manif
 
 | Version | Codename | Description |
 |---|---|---|
+| `3.0.4` | — | **Onboarding patch (2026-06-24).** Fixed: setup wizard no longer gets stuck on step 7/8 for auto-created empty repositories ([#173](https://github.com/d0dg3r/GitSyncMarks/issues/173)) — zero-commit repos treated as empty, greenfield auto-create seeds minimal `bookmarks/` structure automatically, `structureReady` status for structure-only remotes, folder-path validation rejects file-like values such as `bookmarks.json`. |
 | `3.0.3` | — | **Store copy patch (2026-06-17).** Fixed: Chrome Web Store rejection for listing more than five supported platform names — reworded all 12 Chrome/Firefox store locales and the dashboard permission justifications to drop browser/OS/Git-host enumerations and link the full provider list to [docs/PROVIDERS.md](PROVIDERS.md). No functional change. |
 | `3.0.2` | — | **Store copy patch (2026-06-12).** Fixed: Chrome Web Store rejection for excessive provider keywords in listing and manifest descriptions — generic Git-repo wording in all 12 Chrome/Firefox store locales and `_locales` `extDescription` keys. No functional change. |
 | `3.0.1` | — | **AMO patch (2026-06-08).** Fixed: removed unsafe `innerHTML` assignments for Firefox Add-ons linter compliance (`lib/dom-utils.js`, DOM APIs throughout options/popup/search UI). No functional change. |

--- a/lib/whats-new.js
+++ b/lib/whats-new.js
@@ -6,6 +6,12 @@ export const WHATS_NEW_STORAGE_KEY = 'showWhatsNewForVersion';
 
 /** @type {Record<string, { bullets: string[] }>} */
 const WHATS_NEW_BY_VERSION = {
+  '3.0.4': {
+    bullets: [
+      'Onboarding wizard: auto-created empty repositories no longer get stuck at step 7/8 — the initial bookmark folder structure is created automatically.',
+      'Folder path validation: the setup wizard now rejects file-like paths (for example bookmarks.json) and asks for a folder name such as bookmarks.',
+    ],
+  },
   '3.0.3': {
     bullets: [
       'Multi-provider Git sync: each profile can connect to its own Git host (Connection tab).',

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "GitSyncMarks",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "__MSG_extDescriptionFirefox__",
   "default_locale": "en",
   "homepage_url": "https://gitsyncmarks.com",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "GitSyncMarks",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "homepage_url": "https://gitsyncmarks.com",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitsyncmarks",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitsyncmarks",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitsyncmarks",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "private": true,
   "description": "Bookmark sync to your Git repository. Linkwarden, Smart Search, Companion App. Direct, secure, private.",
   "engines": {

--- a/test/whats-new.test.js
+++ b/test/whats-new.test.js
@@ -13,6 +13,13 @@ describe('whats-new', () => {
     assert.ok(c.bullets.length >= 3);
   });
 
+  it('getWhatsNewContent returns bullets for 3.0.4', () => {
+    const c = getWhatsNewContent('3.0.4');
+    assert.ok(c);
+    assert.ok(Array.isArray(c.bullets));
+    assert.ok(c.bullets.some((b) => b.includes('Onboarding wizard')));
+  });
+
   it('getWhatsNewContent returns bullets for 3.0.3', () => {
     const c = getWhatsNewContent('3.0.3');
     assert.ok(c);


### PR DESCRIPTION
## Summary
- Bump extension version to **3.0.4** (manifest, package, lockfile).
- Finalize changelog and release history for the onboarding wizard empty-repo fix ([#173](https://github.com/d0dg3r/GitSyncMarks/issues/173)).
- Add What's New overlay copy for 3.0.4.

## Test plan
- [x] `npm run test:unit`
- [x] `npm run build` (Chrome + Firefox ZIPs)
- [ ] Tag `v3.0.4` after merge to trigger GitHub Release workflow