### PR TITLE
ci: skip GitHub-only workflows on Forgejo Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,11 @@ permissions:
   contents: read
   actions: read
 
+# CodeQL + security-events are GitHub-hosted; Forgejo mirrors lack github/codeql-action.
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    if: ${{ github.server_url == 'https://github.com' }}
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   dependency-review:
     name: Review dependencies
+    if: ${{ github.server_url == 'https://github.com' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,8 +23,10 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+# GitHub Pages actions are not mirrored on data.forgejo.org.
 jobs:
   build:
+    if: ${{ github.server_url == 'https://github.com' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -41,6 +43,7 @@ jobs:
           path: _site
 
   deploy:
+    if: ${{ github.server_url == 'https://github.com' }}
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,12 @@ permissions:
   contents: write
   discussions: write
 
+# Releases, Discussions, and third-party actions (extract-release-notes, softprops)
+# target GitHub; Forgejo action mirrors do not ship those repos.
 jobs:
   quality:
     name: Lint, Typecheck & Unit Tests
+    if: ${{ github.server_url == 'https://github.com' }}
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -38,6 +41,7 @@ jobs:
         run: npm run test:unit
 
   build-and-release:
+    if: ${{ github.server_url == 'https://github.com' }}
     needs: quality
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
Forgejo Actions runs [#3](https://forgejo.devops-geek.net/devops-geek/GitSyncMarks/actions/runs/3)–[#6](https://forgejo.devops-geek.net/devops-geek/GitSyncMarks/actions/runs/6) failed (or flaked) after the v3.0.6 push because the runner clones actions from `data.forgejo.org`, where GitHub-only actions are missing:

- `github/codeql-action` (CodeQL)
- `actions/upload-pages-artifact` (Pages)
- `ffurrer2/extract-release-notes` (Release)

Gate CodeQL / Pages / Release / Dependency Review jobs with `github.server_url == 'https://github.com'`. CI (`ci.yml`) still runs on Forgejo.

## Test plan
- [ ] GitHub CI still green on this PR
- [ ] After merge, Forgejo no longer fails CodeQL/Pages/Release for missing action repos